### PR TITLE
change the Crank Nicholson scheme to use half steps for A and B matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # News
 
+- use half steps in height for A and B matrices in the CN [#28](https://github.com/egavazzi/AURORA.jl/pull/28)
 - make saving simulation data safer [#27](https://github.com/egavazzi/AURORA.jl/pull/27)
 - add scripts to plot I and Q in Julia [#26](https://github.com/egavazzi/AURORA.jl/pull/26)
 - use a finer grid in altitude [#25](https://github.com/egavazzi/AURORA.jl/pull/25)

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -168,6 +168,7 @@ function Crank_Nicolson_Optimized(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     val_r = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
+            # A_tmp = A
             # B_tmp = B[:, i1, i2]
             if μ[i1] < 0    # downward fluxes
                 A_tmp = (A .+ A[[2:end; end]]) ./ 2
@@ -193,13 +194,13 @@ function Crank_Nicolson_Optimized(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
                 append!(val_r, tmp_rhs)
             else
                 if μ[i1] < 0    # downward fluxes
-                    tmp_lhs =   μ[i1] .* Ddz_Down .+ Ddt .+ Diagonal(A/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
-                    tmp_rhs = - μ[i1] .* Ddz_Down .+ Ddt .- Diagonal(A/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
+                    tmp_lhs =   μ[i1] .* Ddz_Down .+ Ddt .+ Diagonal(A_tmp/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
+                    tmp_rhs = - μ[i1] .* Ddz_Down .+ Ddt .- Diagonal(A_tmp/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
                     tmp_lhs[[1, end], :] .= 0
                     tmp_lhs[end, end] = 1
                 else            # upward fluxes
-                    tmp_lhs =   μ[i1] .* Ddz_Up .+ Ddt .+ Diagonal(A/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
-                    tmp_rhs = - μ[i1] .* Ddz_Up .+ Ddt .- Diagonal(A/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
+                    tmp_lhs =   μ[i1] .* Ddz_Up .+ Ddt .+ Diagonal(A_tmp/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
+                    tmp_rhs = - μ[i1] .* Ddz_Up .+ Ddt .- Diagonal(A_tmp/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
                     tmp_lhs[[1, end], :] .= 0
                     tmp_lhs[end, end-1:end] = [-1, 1]
                 end

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -168,7 +168,14 @@ function Crank_Nicolson_Optimized(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     val_r = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
-            B_tmp = B[:, i1, i2]
+            # B_tmp = B[:, i1, i2]
+            if μ[i1] < 0    # downward fluxes
+                A_tmp = (A .+ A[[2:end; end]]) ./ 2
+                B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
+            else            # upward fluxes
+                A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
+                B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
+            end
             if i1 != i2
                 tmp_lhs = -B_tmp/2
                 tmp_lhs[1] = tmp_lhs[end] = 0

--- a/src/steady_state.jl
+++ b/src/steady_state.jl
@@ -26,6 +26,7 @@ function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top)
     val_l = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
+            # A_tmp = A
             # B_tmp = B[:, i1, i2]
             if μ[i1] < 0    # downward fluxes
                 A_tmp = (A .+ A[[2:end; end]]) ./ 2

--- a/src/steady_state.jl
+++ b/src/steady_state.jl
@@ -26,6 +26,7 @@ function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top)
     val_l = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
+            # B_tmp = B[:, i1, i2]
             if μ[i1] < 0    # downward fluxes
                 A_tmp = (A .+ A[[2:end; end]]) ./ 2
                 B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2


### PR DESCRIPTION
Use half steps in height for the matrices A and B in the Crank-Nicholson scheme. 
The explanation is as e- are traveling from an altitude z-1 to z, the calculation of the change in flux due to loss (A) and scattering (B) at the altitude z should be done based on the neutral densities at a 'half step' altitude between z-1 and z.
Indeed, as the electrons are traveling, they 'see' the neutral densities change smoothly between z-1 and z. Taking the neutral densities at a half step situated between z-1 and z should be more physically accurate as it should be kind of an average of the densities experienced by the traveling electrons.

The main effect of this change seems to be a small increase in ionization rates (see figures below).

| WITHOUT half steps in A and B | WITH half steps in A and B |
| -- | -- |
| ![Qz](https://github.com/egavazzi/AURORA.jl/assets/98973824/458d4c57-9e12-43e8-addc-27ab3d0d8bbf) | ![Qz](https://github.com/egavazzi/AURORA.jl/assets/98973824/d5ca2d33-ed10-4ac3-988f-9523aca178f4) |