### PR TITLE
Calculate msis and iri instead of downloading them

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,2 +1,6 @@
 [deps]
 scipy = ""
+
+[pip.deps]
+iri2016 = ""
+pymsis = ""

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # News
 
+- use 'pymsis' and 'iri2016' python packages to get msis and iri data [#30](https://github.com/egavazzi/AURORA.jl/pull/30)
 - add a .JuliaFormatter.toml file for the inbuilt vscode Julia extension formatter
 - use half steps in height for A and B matrices in the CN [#28](https://github.com/egavazzi/AURORA.jl/pull/28)
 - make saving simulation data safer [#27](https://github.com/egavazzi/AURORA.jl/pull/27)


### PR DESCRIPTION
Until now the code was trying to query and download data from https://kauai.ccmc.gsfc.nasa.gov/instantrun/nrlmsis/ and https://kauai.ccmc.gsfc.nasa.gov/instantrun/iri/. However this has shown not to be very stable (query often failing, on server side it seems?). This PR introduces new functions to calculate msis and iri data using the Python packages 'pymsis' and 'iri2016'. We also default to these functions to get msis and iri data.