### PR TITLE
Stop using half-steps for A and B

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # News
 
+## v0.4.1
+- fix bug where ionization rates have too high values [#37](https://github.com/egavazzi/AURORA.jl/pull/37)
+
 ## v0.4.0
 - register the repository on [zenodo.org](https://zenodo.org/)
 - add a .JuliaFormatter.toml file for the inbuilt vscode Julia extension formatter

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -168,15 +168,15 @@ function Crank_Nicolson_Optimized(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     val_r = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
-            # A_tmp = A
-            # B_tmp = B[:, i1, i2]
-            if μ[i1] < 0    # downward fluxes
-                A_tmp = (A .+ A[[2:end; end]]) ./ 2
-                B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
-            else            # upward fluxes
-                A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
-                B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
-            end
+            A_tmp = A
+            B_tmp = B[:, i1, i2]
+            # if μ[i1] < 0    # downward fluxes
+            #     A_tmp = (A .+ A[[2:end; end]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
+            # else            # upward fluxes
+            #     A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
+            # end
             if i1 != i2
                 tmp_lhs = -B_tmp/2
                 tmp_lhs[1] = tmp_lhs[end] = 0

--- a/src/steady_state.jl
+++ b/src/steady_state.jl
@@ -26,16 +26,15 @@ function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top)
     val_l = Vector{Float64}()
     for i1 in axes(B, 2)
         for i2 in axes(B, 2)
-            # A_tmp = A
-            # B_tmp = B[:, i1, i2]
-            if μ[i1] < 0    # downward fluxes
-                A_tmp = (A .+ A[[2:end; end]]) ./ 2
-                B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
-            else            # upward fluxes
-                A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
-                B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
-            end
-
+            A_tmp = A
+            B_tmp = B[:, i1, i2]
+            # if μ[i1] < 0    # downward fluxes
+            #     A_tmp = (A .+ A[[2:end; end]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
+            # else            # upward fluxes
+            #     A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
+            # end
             if i1 != i2
                 tmp_lhs = -B_tmp
                 tmp_lhs[1] = tmp_lhs[end] = 0


### PR DESCRIPTION
Fixes #36

We were using half-steps in height for the A and B matrices. The problem came from doing this with the A matrix but not with the Q matrix. This is (temporarly?) fixed by removing the half-steps for calculating A and B.

## Explanation
To explain the problem lets take an example: 
For a stream of electrons coming down, at an altitude z and energy E we were 'removing' electrons degrading in energy or scattering in pitch-angle. This was done using half-step in height so using neutral densities at altitude (z + 1/2). But now when calculating the matrix Q the 'source' of electrons at lower energies, we are not using neutral densities at altitude z, without taking half-steps. As neutral densities are higher at lower altitudes, this led to an imbalance in the production and loss of electrons, with more electrons being produced than removed.

Below are profiles of Ie at different energies and varying dz.
With halfsteps:
![20keV_changing_dz_from_150km_differentE](https://github.com/egavazzi/AURORA.jl/assets/98973824/d91116cf-5129-48c6-b4bb-dafa0786ad79)

Without halfsteps:
![20keV_changing_dz_from_150km_differentE_nohalfsteps](https://github.com/egavazzi/AURORA.jl/assets/98973824/6a08ad77-ae60-48b7-b293-411f10dc3173)
(x-axis Ie, y-axis altitude)