### PR TITLE
Debug secondaries (again)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,5 +15,5 @@ identifiers:
     value: 10.5281/zenodo.11238620
 repository-code: 'https://github.com/egavazzi/AURORA.jl'
 license: GPL-3.0
-version: 0.4.2
-date-released: '2024-09-05'
+version: 0.4.3
+date-released: '2025-01-02'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # News
 
+## v0.4.3
+- fix bug where secondary e- are not properly redistributed isotropically [#43](https://github.com/egavazzi/AURORA.jl/pull/43)
+
 ## v0.4.2
 - fix bug where ionization rates have too low values due to missing secondary e- [#40](https://github.com/egavazzi/AURORA.jl/pull/40)
 

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -109,7 +109,7 @@ function add_ionization_collisions!(Q, Ie, h_atm, t, n, σ, E_levels, cascading,
                             max.(0, n_repeated_over_t .*
                                 (σ[i_level, iE] .*
                                 Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
-                                BeamWeight[i_μ2] ./ sum(BeamWeight))
+                                BeamWeight[i_μ1] ./ sum(BeamWeight))
                     end
                 end
 
@@ -179,7 +179,7 @@ function prepare_ionization_collisions!(Ie, h_atm, t, n, σ, E_levels, cascading
                             max.(0, n_repeated_over_t .*
                                 (σ[i_level, iE] .*
                                 Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
-                                BeamWeight[i_μ2] ./ sum(BeamWeight))
+                                BeamWeight[i_μ1] ./ sum(BeamWeight))
                     end
                 end
 


### PR DESCRIPTION
Secondaries were not redistributed isotropically due to an indexing error in a loop (which resulted in wrong beam weights (related to solid angles) being applied).

Energy per ionization is basically unchanged. Tested with 2keV precipitation: around 38eV/ionization both before and after the PR, close to lab measurements of 35ev/ionization (Rees, 1989).

Comparisons with rocket measurements look better with this PR compared to before. We had too many secondary electrons propagating field aligned before.

## Before
![IeEup_comparisons_wrong](https://github.com/user-attachments/assets/4c4055d5-e823-40e6-a2f0-97abb7db00b8)


## After
![IeEup_comparisons](https://github.com/user-attachments/assets/cabf0a0b-b242-4daa-977f-137032903eba)
