### PR TITLE
Optimize secondary electrons calculations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # News
+- performance improvement [#44](https://github.com/egavazzi/AURORA.jl/pull/44)
 
 ## v0.4.3
 - fix bug where secondary e- are not properly redistributed isotropically [#43](https://github.com/egavazzi/AURORA.jl/pull/43)

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -103,7 +103,7 @@ function add_ionization_collisions!(Q, Ie, h_atm, t, n, σ, E_levels, cascading,
 
                 Ionizing .= n_repeated_over_μt .* (σ[i_level, iE] .* @view(Ie[:, :, iE]));
                 fill!(Ionization, 0)
-                for i_μ1 in eachindex(μ_center)
+                @views for i_μ1 in eachindex(μ_center)
                     for i_μ2 in eachindex(μ_center)
                         Ionization[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
                             max.(0, n_repeated_over_t .*
@@ -173,7 +173,7 @@ function prepare_ionization_collisions!(Ie, h_atm, t, n, σ, E_levels, cascading
 
                 Ionizing .= n_repeated_over_μt .* (σ[i_level, iE] .* @view(Ie[:, :, iE]));
                 fill!(Ionization, 0)
-                for i_μ1 in eachindex(μ_center)
+                @views for i_μ1 in eachindex(μ_center)
                     for i_μ2 in eachindex(μ_center)
                         Ionization[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
                             max.(0, n_repeated_over_t .*


### PR DESCRIPTION
Leads to a 40% runtime improvement on my machine for a 3keV time-dependent run. Simulation results are unchanged (checked).
