### PR TITLE
Save results anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Allow for saving simulation results anywhere on the system [#57](https://github.com/egavazzi/AURORA.jl/pull/57)
 - Precompile some functions, leading to 10x faster simulation startup in new Julia sessions [#51](https://github.com/egavazzi/AURORA.jl/pull/51), [#52](https://github.com/egavazzi/AURORA.jl/pull/52)
 - Add julia script and functions to make an animation of simulation results [#50](https://github.com/egavazzi/AURORA.jl/pull/50)
 - Rewrite the analysis functions into Julia [#42](https://github.com/egavazzi/AURORA.jl/pull/42)

--- a/scripts/Control_script.jl
+++ b/scripts/Control_script.jl
@@ -1,4 +1,3 @@
-## This is the control script from where simulations are run
 using AURORA
 
 ## Setting parameters
@@ -12,13 +11,6 @@ n_loop = 10;                # number of loops to run
 
 CFL_number = 128;
 
-
-# msis_file = find_nrlmsis_file(
-#     year=2019, month=12, day=7, hour=11, minute=15, lat=76, lon=5, height=85:1:700
-#     );
-# iri_file = find_iri_file(
-#     year=2019, month=12, day=7, hour=11, minute=15, lat=76, lon=5, height=85:1:700
-#     );
 msis_file = find_nrlmsis_file(
     year=2005, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
     );
@@ -26,18 +18,12 @@ iri_file = find_iri_file(
     year=2005, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
     );
 
+## Define where to save the results
+root_savedir = "/home/etienne/Documents"   # name of the root folder
+name_savedir = "test_to_delete"   # name of the experiment folder
+savedir = make_savedir(root_savedir, name_savedir; behavior = "custom")
 
-root_savedir = ""   # name for the root folder where data will be saved (data/root_savedir/)
-name_savedir = ""   # name for the actual data folder of the current experiment (data/root_savedir/name_savedir/...)
-                    # if left empty, the folder will be named using the current date and time (ex: data/root_savedir/20221029-1058/...)
-
-
-
-## Choose the input type ("from_old_matlab_file", "from_file" or "flickering")
-# input_type = "from_old_matlab_file";
-# input_file = "/mnt/data/etienne/AURORA/MI_coupling/TIME2PLAY/conversion_1.27e7-1/Ie_incoming.mat";
-# INPUT_OPTIONS = (;input_type, input_file);
-
+## Define input parameters
 # input_type = "from_file"
 # input_file = "/mnt/data/etienne/Julia/AURORA/data/MI_coupling/1.27e7-1/Ie_precipitating.mat"
 # INPUT_OPTIONS = (;input_type, input_file);
@@ -60,15 +46,12 @@ INPUT_OPTIONS = (;input_type, IeE_tot, z₀, E_min, f, Beams, modulation);
 # t1 = 0;                     # (s) time of end for smooth transition
 # INPUT_OPTIONS = (;input_type, IeE_tot, z₀, E_min, Beams, t0, t1);
 
-
-
 ## Run the simulation
 calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling, n_loop,
-    msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS, CFL_number)
+    msis_file, iri_file, savedir, INPUT_OPTIONS, CFL_number)
 
 ## Run the analysis
-directory_to_process = joinpath("data", root_savedir, name_savedir)
-make_Ie_top_file(directory_to_process)
-make_volume_excitation_file(directory_to_process)
-make_current_file(directory_to_process)
-make_column_excitation_file(directory_to_process)
+make_Ie_top_file(savedir)
+make_volume_excitation_file(savedir)
+make_current_file(savedir)
+make_column_excitation_file(savedir)

--- a/scripts/Control_script_SteadyState.jl
+++ b/scripts/Control_script_SteadyState.jl
@@ -1,26 +1,24 @@
-##
 using AURORA
-using BenchmarkTools
-using MAT
 
-altitude_max = 600;         # (km) top altitude of the ionosphere
-θ_lims = 180:-10:0;         # (°) angle-limits for the electron beams
+## Setting parameters
+altitude_max = 500;         # (km) top altitude of the ionosphere
+θ_lims = 180:-10:10;         # (°) angle-limits for the electron beams
 E_max = 3000;               # (eV) upper limit to the energy grid
 B_angle_to_zenith = 13;     # (°) angle between the B-field line and the zenith
 
 msis_file = find_nrlmsis_file(
-    year=2005, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
+    year=2004, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
     );
 iri_file = find_iri_file(
-    year=2005, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
+    year=2004, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
     );
 
+## Define where to save the results
+root_savedir = ""   # name of the root folder
+name_savedir = ""   # name of the experiment folder
+savedir = make_savedir(root_savedir, name_savedir)
 
-root_savedir = ""   # name for the root folder where data will be saved (data/root_savedir/)
-name_savedir = ""   # name for the actual data folder of the current experiment (data/root_savedir/name_savedir/...)
-
-
-
+## Define input parameters
 input_type = "constant_onset"
 IeE_tot = 1e-2;             # (W/m²) total energy flux of the FAB
 z₀ = altitude_max;          # (km) altitude of the source
@@ -30,6 +28,12 @@ t0 = 0;                     # (s) time of start for smooth transition
 t1 = 0;                     # (s) time of end for smooth transition
 INPUT_OPTIONS = (;input_type, IeE_tot, z₀, E_min, Beams, t0, t1);
 
-
+## Run the simulation
 calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angle_to_zenith,
-    msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS)
+    msis_file, iri_file, savedir, INPUT_OPTIONS);
+
+## Analyze the results
+make_Ie_top_file(savedir)
+make_volume_excitation_file(savedir)
+make_current_file(savedir)
+# make_column_excitation_file(savedir) -- does not make sense for steady-state

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -24,7 +24,7 @@ export Ie_top_from_file, Ie_top_flickering, Ie_top_constant
 export phase_fcn_N2, phase_fcn_O2, phase_fcn_O, convert_phase_fcn_to_3D
 export loss_to_thermal_electrons, beams2beams, make_A, make_B, make_D
 export v_of_E, CFL_criteria, mu_avg, beam_weight, save_parameters, save_results,
-       f_smooth_transition, rename_if_exists, find_Ietop_file
+       f_smooth_transition, rename_if_exists, find_Ietop_file, make_savedir
 export d2M, Crank_Nicolson
 export cascading_N2, cascading_O2, cascading_O
 export update_Q!, update_Q_turbo!

--- a/src/main.jl
+++ b/src/main.jl
@@ -6,9 +6,6 @@ using Term
 function calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling,
     n_loop, msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS,
     CFL_number = 64; savedir_behavior = "default")
-    # Nthreads is a parameter used in add_ionization_collisions! in update_Q!
-    # Nthreads is set to 6 by default as it seems to be optimal on my machine
-
 
     ## Get atmosphere
     h_atm, ne, Te, Tn, E, dE, n_neutrals, E_levels_neutrals, σ_neutrals, μ_lims, μ_center,
@@ -116,7 +113,7 @@ function calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angl
     μ_scatterings = setup(altitude_max, θ_lims, E_max, msis_file, iri_file);
 
     ## Initialise
-    I0 = zeros(length(h_atm) * length(μ_center), length(E));    # starting e- flux profile
+    I0 = zeros(length(h_atm) * length(μ_center), length(E)); # starting e- flux profile
 
     ## Load incoming flux
     if INPUT_OPTIONS.input_type == "from_old_matlab_file"

--- a/src/main.jl
+++ b/src/main.jl
@@ -5,7 +5,7 @@ using Term
 
 function calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling,
     n_loop, msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS,
-    CFL_number = 64)
+    CFL_number = 64; savedir_behavior = "default")
     # Nthreads is a parameter used in add_ionization_collisions! in update_Q!
     # Nthreads is set to 6 by default as it seems to be optimal on my machine
 
@@ -52,24 +52,7 @@ function calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, 
 
 
     ## Create the folder to save the data to
-    # If `root_savedir` is empty or contains only "space" characters, we use "backup/" as a name
-    if isempty(root_savedir) || !occursin(r"[^ ]", root_savedir)
-        root_savedir = "backup"
-    end
-    # If `name_savedir` is empty or contains only "space" characters, we use the current date and time as a name
-    if isempty(name_savedir) || !occursin(r"[^ ]", name_savedir)
-        name_savedir = string(Dates.format(now(), "yyyymmdd-HHMM"))
-    end
-    # Make a string with full path of savedir from root_savedir and name_savedir
-    savedir = pkgdir(AURORA, "data", root_savedir, name_savedir)
-    # Rename `savedir` to `savedir(1)` if it exists and already contain results. If
-    # `savedir(1)` exists then it will be renamed to `savedir(2)` and so on
-    if isdir(savedir) && (filter(startswith("IeFlickering-"), readdir(savedir)) |> length) > 0
-        savedir = rename_if_exists(savedir)
-    end
-    mkpath(savedir)
-    print("\n", @bold "Results will be saved at $savedir \n")
-
+    savedir = make_savedir(root_savedir, name_savedir; behavior = savedir_behavior)
 
     ## And save the simulation parameters in it
     save_parameters(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling, t, n_loop,
@@ -168,24 +151,7 @@ function calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angl
 
 
     ## Create the folder to save the data to
-    if isempty(root_savedir) || !occursin(r"[^ ]", root_savedir)
-        # if root_savedir is empty or contains only "space" characters, we use "backup/" as a name
-        root_savedir = "backup"
-    end
-    if isempty(name_savedir) || !occursin(r"[^ ]", name_savedir)
-        # if name_savedir is empty or contains only "space" characters, we use the current
-        # date and time as a name
-        name_savedir = string(Dates.format(now(), "yyyymmdd-HHMM"))
-    end
-    # Make a string with full path of savedir from root_savedir and name_savedir
-    savedir = pkgdir(AURORA, "data", root_savedir, name_savedir)
-    # Rename `savedir` to `savedir(1)` if it exists and already contain results. If
-    # `savedir(1)` exists then it will be renamed to `savedir(2)` and so on
-    if isdir(savedir) && (filter(startswith("IeFlickering-"), readdir(savedir)) |> length) > 0
-        savedir = rename_if_exists(savedir)
-    end
-    mkpath(savedir)
-    print("\n", @bold "Results will be saved at $savedir \n")
+    savedir = make_savedir(root_savedir, name_savedir; behavior = savedir_behavior)
 
     ## And save the simulation parameters in it
     save_parameters(altitude_max, θ_lims, E_max, B_angle_to_zenith, 1:1:1, 1:1:1, 1,

--- a/src/main.jl
+++ b/src/main.jl
@@ -110,7 +110,7 @@ end
 
 
 function calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angle_to_zenith,
-    msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS)
+    msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS; savedir_behavior = "default")
     ## Get atmosphere
     h_atm, ne, Te, Tn, E, dE, n_neutrals, E_levels_neutrals, σ_neutrals, μ_lims, μ_center,
     μ_scatterings = setup(altitude_max, θ_lims, E_max, msis_file, iri_file);

--- a/src/main.jl
+++ b/src/main.jl
@@ -4,8 +4,7 @@ using Dates
 using Term
 
 function calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling,
-    n_loop, msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS,
-    CFL_number = 64; savedir_behavior = "default")
+    n_loop, msis_file, iri_file, savedir, INPUT_OPTIONS, CFL_number = 64)
 
     ## Get atmosphere
     h_atm, ne, Te, Tn, E, dE, n_neutrals, E_levels_neutrals, σ_neutrals, μ_lims, μ_center,
@@ -46,10 +45,6 @@ function calculate_e_transport(altitude_max, θ_lims, E_max, B_angle_to_zenith, 
     phaseOe, phaseOi = phase_fcn_O(μ_scatterings.theta1, E);
     phase_fcn_neutrals = ((phaseN2e, phaseN2i), (phaseO2e, phaseO2i), (phaseOe, phaseOi));
     cascading_neutrals = (cascading_N2, cascading_O2, cascading_O) # tuple of functions
-
-
-    ## Create the folder to save the data to
-    savedir = make_savedir(root_savedir, name_savedir; behavior = savedir_behavior)
 
     ## And save the simulation parameters in it
     save_parameters(altitude_max, θ_lims, E_max, B_angle_to_zenith, t_sampling, t, n_loop,
@@ -107,7 +102,7 @@ end
 
 
 function calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angle_to_zenith,
-    msis_file, iri_file, root_savedir, name_savedir, INPUT_OPTIONS; savedir_behavior = "default")
+    msis_file, iri_file, savedir, INPUT_OPTIONS)
     ## Get atmosphere
     h_atm, ne, Te, Tn, E, dE, n_neutrals, E_levels_neutrals, σ_neutrals, μ_lims, μ_center,
     μ_scatterings = setup(altitude_max, θ_lims, E_max, msis_file, iri_file);
@@ -145,10 +140,6 @@ function calculate_e_transport_steady_state(altitude_max, θ_lims, E_max, B_angl
     phaseOe, phaseOi = phase_fcn_O(μ_scatterings.theta1, E);
     phase_fcn_neutrals = ((phaseN2e, phaseN2i), (phaseO2e, phaseO2i), (phaseOe, phaseOi));
     cascading_neutrals = (cascading_N2, cascading_O2, cascading_O) # tuple of functions
-
-
-    ## Create the folder to save the data to
-    savedir = make_savedir(root_savedir, name_savedir; behavior = savedir_behavior)
 
     ## And save the simulation parameters in it
     save_parameters(altitude_max, θ_lims, E_max, B_angle_to_zenith, 1:1:1, 1:1:1, 1,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -227,13 +227,13 @@ end
     make_savedir(root_savedir, name_savedir; behavior = "default")
 
 Return the path to the directory where the results will be saved. If the directory does not
-already exist, it will be created.
+already exist, create it.
 
 If the constructed `savedir` already exists and contains files starting with `"IeFlickering-"`,
 a new directory is created to avoid accidental overwriting of results (e.g., `savedir(1)`, `savedir(2)`, etc.).
 
 # Calling
-`savedir = make_savedir(root_savedir, name_savedir)`
+`savedir = make_savedir(root_savedir, name_savedir)` \\
 `savedir = make_savedir(root_savedir, name_savedir; behavior = "custom")`
 
 # Arguments
@@ -242,7 +242,7 @@ a new directory is created to avoid accidental overwriting of results (e.g., `sa
 - `name_savedir::String`: The name of the subdirectory to be created within `root_savedir`.
     If empty or contains only spaces, it defaults to the current date and time in the
     format `"yyyymmdd-HHMM"`.
-- `behavior::String` (optional): Determines how the full path of the save directory is constructed.
+- `behavior::String` (optional): Determines how the full path is constructed.
     - `"default"`: The path will be built starting under the `data/` folder of the AURORA installation
         (i.e., `AURORA_folder/data/root_savedir/name_savedir/`, where `AURORA_folder` is
         the folder containing the AURORA code). This is the default behavior.
@@ -269,7 +269,7 @@ function make_savedir(root_savedir, name_savedir; behavior = "default")
     if behavior == "default"
         savedir = pkgdir(AURORA, "data", root_savedir, name_savedir)
     elseif behavior == "custom"
-        savedir = pkgdir(root_savedir, name_savedir)
+        savedir = joinpath(root_savedir, name_savedir)
     end
 
     # Rename `savedir` to `savedir(1)` if it exists and already contain results. If


### PR DESCRIPTION
Make it possible to save results of simulations anywhere on the system (relative or absolute path), while it was only possible to save them in the `data/` folder of the AURORA directory before.

## TODO
- [x] add an entry in CHANGELOG.md
- [x] update the control scripts templates
