### PR TITLE
Make things faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Improved performances, making simulations around 3x faster to run [#64](https://github.com/egavazzi/AURORA.jl/pull/64)
+
 ## v0.5.0 - 2025-05-01
 - Faster phase functions calculations [#62](https://github.com/egavazzi/AURORA.jl/pull/62)
 - Make it possible to choose a bottom altitude for the ionosphere [#58](https://github.com/egavazzi/AURORA.jl/pull/58)

--- a/internal_data/data_electron/e_N2_cross_sections.jl
+++ b/internal_data/data_electron/e_N2_cross_sections.jl
@@ -70,7 +70,7 @@ function e_N2rot0_2(Ep)
 
     cross_section = cross_section / 1e4
 
-    cross_section[Ep .> 10] .= 0 #TODO: FIX THIS/BG20190312  # wonder why? /EG20230924 # still wonder why (and slightly ashamed of working on a 1st of May) /EG20250101
+    cross_section[Ep .> 10] .= 0 #TODO: FIX THIS/BG20190312  # wonder why? /EG20230924 # still wonder why /EG20250504
     cross_section[Ep .< 0.001480105560000] .= 0
 
     return cross_section

--- a/scripts/plotting/Compare_Ie.jl
+++ b/scripts/plotting/Compare_Ie.jl
@@ -1,3 +1,5 @@
+# Kind of a WIP
+
 using AURORA
 using MAT
 using CairoMakie

--- a/scripts/plotting/Compare_Ie.jl
+++ b/scripts/plotting/Compare_Ie.jl
@@ -1,0 +1,161 @@
+using AURORA
+using MAT
+using CairoMakie
+CairoMakie.activate!()
+# using GLMakie
+# GLMakie.activate!()
+
+
+## This is for simple cases of comparison where z-grid and t-grid are the same
+# Path to data folder 1
+# full_path_to_data1 = "data/backup/20250504-2044/IeFlickering-01.mat"
+full_path_to_data1 = "data/compare/new_1keV_constant_CFL256/IeFlickering-01.mat"
+# Path to data folder 2
+# full_path_to_data2 = "data/backup/20250504-2027/IeFlickering-01.mat"
+full_path_to_data2 = "data/compare/new_1keV_oldQ_constant_CFL256/IeFlickering-01.mat"
+
+# Read the data (electron number flux)
+# From data folder 1
+data = matread(full_path_to_data1)
+Ie1 = data["Ie_ztE"]
+h_atm = vec(data["h_atm"]) ./ 1e3 # convert to km
+t = vec(data["t_run"])
+E = data["E"]
+μ_lims = data["mu_lims"]
+# From data folder 2
+data = matread(full_path_to_data2)
+Ie2 = data["Ie_ztE"]
+
+
+Ie1_4D = AURORA.restructure_Ie_from_3D_to_4D(Ie1, μ_lims, h_atm, t, E);
+Ie2_4D = AURORA.restructure_Ie_from_3D_to_4D(Ie2, μ_lims, h_atm, t, E);
+
+# Plot Ie data + difference (fixed time, in height and energy)
+i_μ = 1
+i_t = length(t)
+
+data_plot1 = Ie1_4D[i_μ, :, i_t, :];
+data_plot2 = Ie2_4D[i_μ, :, i_t, :];
+
+##
+Theme(Axis = (xticksmirrored = true, yticksmirrored = true, xminorticksvisible = true,
+              yminorticksvisible = true, limits = (nothing, (nothing, 400))),
+      Heatmap = (rasterize = true,),
+      Colorbar = (flip_vertical_label = true, vertical = true))
+
+fig = Figure(size = (1600, 800))
+Label(fig[0, 1:2],
+        "Ie1: " * split(full_path_to_data1, "/")[end - 1] * "\n" *
+        "Ie2: " * split(full_path_to_data2, "/")[end - 1],
+        tellheight = true, tellwidth = false, font = :bold, halign = :left,
+        justification = :left)
+
+# First row : 4278 Å
+colorlims = (0, maximum([maximum(data_plot1), maximum(data_plot2)]))
+# colorlims_diff = (-maximum(abs.(data_plot1 - data_plot2)), maximum(abs.(data_plot1 - data_plot2)))
+colorlims_diff = (1e-10, maximum(abs.(data_plot1 - data_plot2)))
+ga_1 = fig[1, 1] = GridLayout()
+ax1 = Axis(ga_1[1, 1]; title = "Ie1", ylabel = "altitude (km)")
+hm1 = heatmap!(E, h_atm, data_plot1'; colorrange = colorlims)
+cb1 = Colorbar(ga_1[1, 2], hm1; label = "")
+colgap!(ga_1, 10)
+ga_2 = fig[2, 1] = GridLayout()
+ax2 = Axis(ga_2[1, 1]; title = "Ie2", ylabel = "altitude (km)")
+hm2 = heatmap!(E, h_atm, data_plot2'; colorrange = colorlims)
+cb2 = Colorbar(ga_2[1, 2], hm2; label = "")
+colgap!(ga_2, 10)
+if data_plot1 != data_plot2
+    ga_3 = fig[1:2, 2:3] = GridLayout()
+    ax3 = Axis(ga_3[1, 1]; title = "Difference (1 - 2)",
+                    yticklabelsvisible = false)
+    hm3 = heatmap!(E, h_atm, abs.(data_plot1 - data_plot2)';
+                        colormap = :RdBu, colorscale=log10, colorrange = colorlims_diff)
+    cb3 = Colorbar(ga_3[1, 2], hm3; label = "")
+    colgap!(ga_3, 10)
+    ga_4 = fig[1:2, 4] = GridLayout()
+    ax4 = Axis(ga_4[1, 1]; title = "Relative difference (1 - 2)",
+                    yticklabelsvisible = false)
+    hm4 = heatmap!(E, h_atm, (abs.(data_plot1 - data_plot2) ./ data_plot1)';
+            colormap = :cividis, colorrange = (0, 1))
+    cb4 = Colorbar(ga_4[1, 2], hm4; label = "relative difference")
+    colgap!(ga_4, 10)
+
+    # xlims!(ax1, 0, 20)
+    # xlims!(ax2, 0, 20)
+    # xlims!(ax3, 0, 20)
+else
+    Label(fig[:, 2], "The results are exactly the same", tellwidth = false)
+end
+
+display(fig)
+# display(GLMakie.Screen(), fig)
+
+
+
+
+
+##
+
+# Plot Ie data + difference (fixed energy, in height and time)
+i_μ = 1
+iE = 10
+data_plot1 = Ie1_4D[i_μ, :, :, iE];
+data_plot2 = Ie2_4D[i_μ, :, :, iE];
+
+#
+Theme(Axis = (xticksmirrored = true, yticksmirrored = true, xminorticksvisible = true,
+              yminorticksvisible = true, limits = (nothing, (nothing, 400))),
+      Heatmap = (rasterize = true,),
+      Colorbar = (flip_vertical_label = true, vertical = true))
+
+fig = Figure(size = (1600, 800))
+Label(fig[0, 1:2],
+        "Ie1: " * split(full_path_to_data1, "/")[end - 1] * "\n" *
+        "Ie2: " * split(full_path_to_data2, "/")[end - 1],
+        tellheight = true, tellwidth = false, font = :bold, halign = :left,
+        justification = :left)
+
+Label(fig[0, 4],
+        "E = $(E[iE])",
+        tellheight = true, tellwidth = false, font = :bold, halign = :left,
+        justification = :left)
+
+# First row : 4278 Å
+colorlims = (0, maximum([maximum(data_plot1), maximum(data_plot2)]))
+# colorlims_diff = (-maximum(abs.(data_plot1 - data_plot2)), maximum(abs.(data_plot1 - data_plot2)))
+colorlims_diff = (1e-6, maximum(abs.(data_plot1 - data_plot2)))
+ga_1 = fig[1, 1] = GridLayout()
+ax1 = Axis(ga_1[1, 1]; title = "Ie1", ylabel = "altitude (km)")
+hm1 = heatmap!(t, h_atm, data_plot1'; colorrange = colorlims)
+cb1 = Colorbar(ga_1[1, 2], hm1; label = "")
+colgap!(ga_1, 10)
+ga_2 = fig[2, 1] = GridLayout()
+ax2 = Axis(ga_2[1, 1]; title = "Ie2", ylabel = "altitude (km)")
+hm2 = heatmap!(t, h_atm, data_plot2'; colorrange = colorlims)
+cb2 = Colorbar(ga_2[1, 2], hm2; label = "")
+colgap!(ga_2, 10)
+if data_plot1 != data_plot2
+    ga_3 = fig[1:2, 2:3] = GridLayout()
+    ax3 = Axis(ga_3[1, 1]; title = "Difference (1 - 2)",
+                    yticklabelsvisible = false)
+    hm3 = heatmap!(t, h_atm, abs.(data_plot1 - data_plot2)';
+                        colormap = :RdBu, colorscale=log10, colorrange = colorlims_diff)
+    cb3 = Colorbar(ga_3[1, 2], hm3; label = "")
+    colgap!(ga_3, 10)
+    ga_4 = fig[1:2, 4] = GridLayout()
+    ax4 = Axis(ga_4[1, 1]; title = "Relative difference (1 - 2)",
+                    yticklabelsvisible = false)
+    hm4 = heatmap!(t, h_atm, (abs.(data_plot1 - data_plot2) ./ data_plot1)';
+            colormap = :cividis, colorrange = (0, 1))
+    cb4 = Colorbar(ga_4[1, 2], hm4; label = "relative difference")
+    colgap!(ga_4, 10)
+
+    # xlims!(ax1, 0, 20)
+    # xlims!(ax2, 0, 20)
+    # xlims!(ax3, 0, 20)
+else
+    Label(fig[:, 2], "The results are exactly the same", tellwidth = false)
+end
+
+display(fig)
+# display(GLMakie.Screen(), fig)

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -27,7 +27,7 @@ export v_of_E, CFL_criteria, mu_avg, beam_weight, save_parameters, save_results,
        f_smooth_transition, rename_if_exists, find_Ietop_file, make_savedir
 export d2M, Crank_Nicolson
 export cascading_N2, cascading_O2, cascading_O
-export update_Q!, update_Q_turbo!, new_Q!
+export update_Q!
 
 include("main.jl")
 export calculate_e_transport

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -27,7 +27,7 @@ export v_of_E, CFL_criteria, mu_avg, beam_weight, save_parameters, save_results,
        f_smooth_transition, rename_if_exists, find_Ietop_file, make_savedir
 export d2M, Crank_Nicolson
 export cascading_N2, cascading_O2, cascading_O
-export update_Q!, update_Q_turbo!
+export update_Q!, update_Q_turbo!, new_Q!
 
 include("main.jl")
 export calculate_e_transport

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -16,8 +16,127 @@ function d2M(z)
 end
 
 
-using KLU: klu
-function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
+using KLU: klu, klu!
+function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; first_iteration = false)
+    Ie = Array{Float64}(undef, length(h_atm) * length(μ), length(t))
+
+    # Spatial differentiation matrices, for up and down streams
+    # Here we tuck on a fictious height one tick below lowest height and on tick above highest
+    # height just to make it possible to use the diff function.
+    h4diffu = [h_atm[1] - (h_atm[2] - h_atm[1]) ; h_atm]
+    h4diffd = [h_atm ; h_atm[end] + (h_atm[end] - h_atm[end-1])]
+    Ddz_Up   = spdiagm(-1 => -1 ./ (2 .* diff(h4diffu[2:end])),
+                        0 =>  1 ./ (2 .* diff(h4diffu[1:end])))
+    Ddz_Down = spdiagm( 0 => -1 ./ (2 .* diff(h4diffd[1:end])),
+                        1 =>  1 ./ (2 .* diff(h4diffd[1:end-1])))
+
+    # Temporal differentiation matrix
+    dt = t[2] - t[1]
+    Ddt = Diagonal([1 ./ (v * dt) for i in h_atm])
+
+    # Diffusion operator
+    Ddiffusion = d2M(h_atm)
+    Ddiffusion[1, 1] = 0
+
+    # Building the CN matrices
+    Nz = length(h_atm)
+    row_l = Vector{Int64}() # maybe using sizehint could help?
+    col_l = Vector{Int64}()
+    val_l = Vector{Float64}()
+    row_r = Vector{Int64}()
+    col_r = Vector{Int64}()
+    val_r = Vector{Float64}()
+    for i1 in axes(B, 2)
+        for i2 in axes(B, 2)
+            A_tmp = A
+            B_tmp = B[:, i1, i2]
+            # if μ[i1] < 0    # downward fluxes
+            #     A_tmp = (A .+ A[[2:end; end]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
+            # else            # upward fluxes
+            #     A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
+            # end
+            if i1 != i2
+                tmp_lhs = -B_tmp/2
+                tmp_lhs[1] = tmp_lhs[end] = 0
+
+                tmp_rhs = B_tmp/2
+                tmp_rhs[1] = tmp_rhs[end] = 0
+
+                idx_row = (i1 - 1) * Nz .+ (1:Nz)
+                idx_col = (i2 - 1) * Nz .+ (1:Nz)
+                append!(row_l, idx_row)
+                append!(col_l, idx_col)
+                append!(val_l, tmp_lhs)
+                append!(row_r, idx_row)
+                append!(col_r, idx_col)
+                append!(val_r, tmp_rhs)
+            else
+                if μ[i1] < 0    # downward fluxes
+                    tmp_lhs =   μ[i1] .* Ddz_Down .+ Ddt .+ Diagonal(A_tmp/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
+                    tmp_rhs = - μ[i1] .* Ddz_Down .+ Ddt .- Diagonal(A_tmp/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
+                    tmp_lhs[[1, end], :] .= 0
+                    tmp_lhs[end, end] = 1
+                else            # upward fluxes
+                    tmp_lhs =   μ[i1] .* Ddz_Up .+ Ddt .+ Diagonal(A_tmp/2) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp/2)
+                    tmp_rhs = - μ[i1] .* Ddz_Up .+ Ddt .- Diagonal(A_tmp/2) .+ D[i1] .* Ddiffusion .+ Diagonal( B_tmp/2)
+                    tmp_lhs[[1, end], :] .= 0
+                    tmp_lhs[end, end-1:end] = [-1, 1]
+                end
+                tmp_rhs[[1, end], :] .= 0
+                tmp_lhs[1, 1] = 1
+
+                idx_row = (i1 - 1) * Nz .+ findnz(tmp_lhs)[1]
+                idx_col = (i2 - 1) * Nz .+ findnz(tmp_lhs)[2]
+                append!(row_l, idx_row)
+                append!(col_l, idx_col)
+                append!(val_l, findnz(tmp_lhs)[3])
+                idx_row = (i1 - 1) * Nz .+ findnz(tmp_rhs)[1]
+                idx_col = (i2 - 1) * Nz .+ findnz(tmp_rhs)[2]
+                append!(row_r, idx_row)
+                append!(col_r, idx_col)
+                append!(val_r, findnz(tmp_rhs)[3])
+            end
+        end
+    end
+    Mlhs = sparse!(row_l, col_l, val_l)
+    Mrhs = sparse!(row_r, col_r, val_r)
+    dropzeros!(Mlhs)    # for performance
+    dropzeros!(Mrhs)    # for performance
+
+    index_top_bottom = sort(vcat(1:length(h_atm):(length(μ)*length(h_atm)),
+                            length(h_atm):length(h_atm):(length(μ)*length(h_atm))))
+
+    i_t = 1
+    Ie[:, 1] = I0
+    Ie_finer = I0
+    b = similar(Ie_finer)
+
+    first_iteration ? KLU_cache = klu(Mlhs) : klu!(KLU_cache, Mlhs)
+
+    for i_t in 1:length(t) - 1
+        I_top_bottom = (@view(Ie_top[:, i_t]) * [0, 1]')'
+        Q_local = (@view(Q[:, i_t]) .+ @view(Q[:, i_t + 1])) ./ 2
+        Q_local[index_top_bottom] = I_top_bottom[:]
+
+        mul!(b, Mrhs, Ie_finer)
+        Ie_finer .= b
+        Ie_finer .+= Q_local
+        ldiv!(KLU_cache, Ie_finer)
+
+        Ie[:, i_t + 1] = Ie_finer
+    end
+    Ie[Ie .< 0] .= 0; # the fluxes should never be negative
+
+    if first_iteration
+        return Ie, KLU_cache
+    else
+        return Ie
+    end
+end
+
+function Crank_Nicolson_old(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     Ie = Array{Float64}(undef, length(h_atm) * length(μ), length(t))
 
     # Spatial differentiation matrices, for up and down streams
@@ -102,8 +221,8 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     end
     Mlhs = sparse(row_l, col_l, val_l)
     Mrhs = sparse(row_r, col_r, val_r)
-    dropzeros!(Mlhs)    # for the performance of the next calculations
-    dropzeros!(Mrhs)    # for the performance of the next calculations
+    dropzeros!(Mlhs)    # for performance
+    dropzeros!(Mrhs)    # for performance
 
     index_top_bottom = sort(vcat(1:length(h_atm):(length(μ)*length(h_atm)),
                             length(h_atm):length(h_atm):(length(μ)*length(h_atm))))
@@ -113,8 +232,7 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
     Ie_finer = I0
     b = similar(Ie_finer)
 
-    # klu!(AAA, Mlhs)
-    AAA = klu(Mlhs)
+    KLU_cache = klu(Mlhs)
 
     for i_t in 1:length(t) - 1
         I_top_bottom = (@view(Ie_top[:, i_t]) * [0, 1]')'
@@ -124,10 +242,12 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)
         mul!(b, Mrhs, Ie_finer)
         Ie_finer .= b
         Ie_finer .+= Q_local
-        ldiv!(AAA, Ie_finer)
+        ldiv!(KLU_cache, Ie_finer)
 
         Ie[:, i_t + 1] = Ie_finer
     end
     Ie[Ie .< 0] .= 0; # the fluxes should never be negative
+
+
     return Ie
 end

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -17,7 +17,7 @@ end
 
 
 using KLU: klu, klu!
-function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; first_iteration = false)
+function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, cache; first_iteration = false)
     Ie = Array{Float64}(undef, length(h_atm) * length(μ), length(t))
 
     # Spatial differentiation matrices, for up and down streams
@@ -114,9 +114,9 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; firs
     b = similar(Ie_finer)
 
     if first_iteration
-        global KLU_cache = klu(Mlhs)
+        cache.KLU = klu(Mlhs)
     else
-        klu!(KLU_cache, Mlhs)
+        klu!(cache.KLU, Mlhs)
     end
 
     for i_t in 1:length(t) - 1
@@ -127,7 +127,7 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; firs
         mul!(b, Mrhs, Ie_finer)
         Ie_finer .= b
         Ie_finer .+= Q_local
-        ldiv!(KLU_cache, Ie_finer)
+        ldiv!(cache.KLU, Ie_finer)
 
         Ie[:, i_t + 1] = Ie_finer
     end

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -50,13 +50,6 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, cache; first_it
         for i2 in axes(B, 2)
             A_tmp = A
             B_tmp = B[:, i1, i2]
-            # if μ[i1] < 0    # downward fluxes
-            #     A_tmp = (A .+ A[[2:end; end]]) ./ 2
-            #     B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
-            # else            # upward fluxes
-            #     A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
-            #     B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
-            # end
             if i1 != i2
                 tmp_lhs = -B_tmp/2
                 tmp_lhs[1] = tmp_lhs[end] = 0

--- a/src/crank_nicolson.jl
+++ b/src/crank_nicolson.jl
@@ -113,7 +113,11 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; firs
     Ie_finer = I0
     b = similar(Ie_finer)
 
-    first_iteration ? KLU_cache = klu(Mlhs) : klu!(KLU_cache, Mlhs)
+    if first_iteration
+        global KLU_cache = klu(Mlhs)
+    else
+        klu!(KLU_cache, Mlhs)
+    end
 
     for i_t in 1:length(t) - 1
         I_top_bottom = (@view(Ie_top[:, i_t]) * [0, 1]')'
@@ -129,11 +133,7 @@ function Crank_Nicolson(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0, KLU_cache; firs
     end
     Ie[Ie .< 0] .= 0; # the fluxes should never be negative
 
-    if first_iteration
-        return Ie, KLU_cache
-    else
-        return Ie
-    end
+    return Ie
 end
 
 function Crank_Nicolson_old(t, h_atm, μ, v, A, B, D, Q, Ie_top, I0)

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -21,10 +21,12 @@ end
 
 function build_big_B2B(B2B_inelastic, n, h_atm)
     n_elements = size(B2B_inelastic, 1) * size(B2B_inelastic, 2) * length(h_atm)
+    # idx1 = zeros(Int64, n_elements)
+    # idx2 = zeros(Int64, n_elements)
+    # aB2B = zeros(n_elements)
     idx1 = Vector{Int}(undef, n_elements)
     idx2 = Vector{Int}(undef, n_elements)
     aB2B = Vector{Float64}(undef, n_elements)
-
     counter = 1
     for i1 in axes(B2B_inelastic, 1)
         for i2 in axes(B2B_inelastic, 2)

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -365,9 +365,9 @@ function new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutr
         # If the energy is too low, skip the ionization calculation (use zeros)
         idx_ionization = (E_levels[:, 2] .> 0)
         if minimum(E_levels[idx_ionization, 1]) < E[iE]
-            prepare_first_fragment!(Ionization_fragment_1[i], Ionizing_fragment_1[i],
+            prepare_first_ionization_fragment!(Ionization_fragment_1[i], Ionizing_fragment_1[i],
                                     n, Ie, t, h_atm, μ_center, BeamWeight, iE)
-            prepare_second_fragment!(Ionization_fragment_2[i], Ionizing_fragment_2[i],
+            prepare_second_ionization_fragment!(Ionization_fragment_2[i], Ionizing_fragment_2[i],
                                     σ, E_levels, cascading, E, dE, iE)
         end
     end
@@ -376,12 +376,10 @@ function new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutr
                               Ionization_fragment_2, Ionizing_fragment_2)
 end
 
-function prepare_first_fragment!(Ionization_fragment_1, Ionizing_fragment_1,
+function prepare_first_ionization_fragment!(Ionization_fragment_1, Ionizing_fragment_1,
                                       n, Ie, t, h_atm, μ_center, BeamWeight, iE)
     n_repeated_over_μt = repeat(n, length(μ_center), length(t))
     n_repeated_over_t = repeat(n, 1, length(t))
-
-    # TODO IDEA: check if E[iE] is enough to ionize, otherwise do nothing
 
     # PRIMARY ELECTRONS
     Ionizing_fragment_1 .= n_repeated_over_μt .* @view(Ie[:, :, iE]);
@@ -390,14 +388,14 @@ function prepare_first_fragment!(Ionization_fragment_1, Ionizing_fragment_1,
     @views for i_μ1 in eachindex(μ_center)
         for i_μ2 in eachindex(μ_center)
             Ionization_fragment_1[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
-                max.(0, n_repeated_over_t .*
+                n_repeated_over_t .*
                     (Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
-                    BeamWeight[i_μ1] ./ sum(BeamWeight))
+                    BeamWeight[i_μ1] ./ sum(BeamWeight)
         end
     end
 end
 
-function prepare_second_fragment!(Ionization_fragment_2, Ionizing_fragment_2,
+function prepare_second_ionization_fragment!(Ionization_fragment_2, Ionizing_fragment_2,
                                             σ, E_levels, cascading, E, dE, iE)
     # Loop through the different collisions for the current neutral species
     for i_level in axes(E_levels, 1)[2:end]

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -362,7 +362,7 @@ function new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutr
         # fill!(Ionization_fragment_2[i], 0)
         # fill!(Ionizing_fragment_2[i], 0)
         prepare_first_fragment!(Ionization_fragment_1[i], Ionizing_fragment_1[i],
-                                n, t, h_atm, μ_center, BeamWeight)
+                                n, Ie, t, h_atm, μ_center, BeamWeight, iE)
         prepare_second_fragment!(Ionization_fragment_2[i], Ionizing_fragment_2[i],
                                  σ, E_levels, cascading, E, dE, iE)
     end
@@ -372,9 +372,11 @@ function new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutr
 end
 
 function prepare_first_fragment!(Ionization_fragment_1, Ionizing_fragment_1,
-                                      n, t, h_atm, μ_center, BeamWeight)
+                                      n, Ie, t, h_atm, μ_center, BeamWeight, iE)
     n_repeated_over_μt = repeat(n, length(μ_center), length(t))
     n_repeated_over_t = repeat(n, 1, length(t))
+
+    # TODO IDEA: check if E[iE] is enough to ionize, otherwise do nothing
 
     # PRIMARY ELECTRONS
     Ionizing_fragment_1 .= n_repeated_over_μt .* @view(Ie[:, :, iE]);

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -1,315 +1,11 @@
 using LoopVectorization: @tturbo
 using SparseArrays: sparse!
 
-#################################################################################
-#                                   B2B matrix                                  #
-#################################################################################
-function make_big_B2B_matrix(B2B_inelastic, n, h_atm)
-    idx1 = Vector{Int}(undef, 0)
-    idx2 = Vector{Int}(undef, 0)
-    aB2B = Vector{Float64}(undef, 0)
-    for i1 in axes(B2B_inelastic, 1)
-        for i2 in axes(B2B_inelastic, 2)
-            append!(idx1, (i1 - 1) * length(h_atm) .+ (1:length(h_atm)))
-            append!(idx2, (i2 - 1) * length(h_atm) .+ (1:length(h_atm)))
-            append!(aB2B, n * B2B_inelastic[i1, i2])
-        end
-    end
-    AB2B = sparse!(idx1, idx2, aB2B)
-    return AB2B
-end
-
-function build_big_B2B(B2B_inelastic, n, h_atm)
-    n_elements = size(B2B_inelastic, 1) * size(B2B_inelastic, 2) * length(h_atm)
-    # idx1 = zeros(Int64, n_elements)
-    # idx2 = zeros(Int64, n_elements)
-    # aB2B = zeros(n_elements)
-    idx1 = Vector{Int}(undef, n_elements)
-    idx2 = Vector{Int}(undef, n_elements)
-    aB2B = Vector{Float64}(undef, n_elements)
-    counter = 1
-    for i1 in axes(B2B_inelastic, 1)
-        for i2 in axes(B2B_inelastic, 2)
-            idx_range = counter:(counter + length(h_atm) - 1)
-            idx1[idx_range] .= (i1 - 1) * length(h_atm) .+ (1:length(h_atm))
-            idx2[idx_range] .= (i2 - 1) * length(h_atm) .+ (1:length(h_atm))
-            aB2B[idx_range] .= n * B2B_inelastic[i1, i2]
-            counter += length(h_atm)
-        end
-    end
-
-    return sparse!(idx1, idx2, aB2B)
-end
-
-# After some trial and error, I managed to find in what order the elements of the B2B sparse
-# matrix are stored in memory. Here we update these values in place. What would'nt we do
-# for better performance eh?
-function update_big_B2B!(AB2B, B2B_inelastic, n)
-    counter = 1
-    n_μ = size(B2B_inelastic, 2)
-    @views for i1 in axes(B2B_inelastic, 2)
-        for i2 in eachindex(n)
-            idx_range = counter:(counter + n_μ - 1)
-            AB2B.nzval[idx_range] .= n[i2] .* B2B_inelastic[:, i1]
-            counter += n_μ
-        end
-    end
-    return nothing
-end
-
-
-
-#################################################################################
-#                               Inelastic collisions                            #
-#################################################################################
-
-
-function add_inelastic_collisions!(Q, Ie, h_atm, n, σ, E_levels, B2B_inelastic, E, dE, iE, cache)
-    # Initialize
-    Ie_degraded = Matrix{Float64}(undef, size(Ie, 1), size(Ie, 2))
-
-    # Multiply each element of B2B with n (density vector) and resize to get a matrix that
-    # can be multiplied with Ie
-    if iE == length(E)
-        # build the matrix the first time
-        cache.AB2B = build_big_B2B(B2B_inelastic, n, h_atm)
-    else
-        # then reuse the sparse structure and just update the values
-        update_big_B2B!(cache.AB2B, B2B_inelastic, n)
-    end
-
-    # Then calculate the flux of electrons that scatter
-    Ie_scatter = cache.AB2B * @view(Ie[:, :, iE])
-
-    # Loop over the energy levels of the collisions with the i-th neutral species
-    for i_level in axes(E_levels, 1)[2:end]
-        if E_levels[i_level, 2] <= 0  # these collisions should not produce secondary e-
-            # The flux of e- degraded from energy bin [E[iE], E[iE] + dE[iE]] to any lower
-            # energy bin by excitation of the E_levels[i_level] state of the current
-            # species. The second factor corrects for the case where the energy loss is
-            # smaller than the width in energy of the energy bin. That is, when dE[iE] >
-            # E_levels[i_level,1], only the fraction E_levels[i_level,1] / dE[iE] is lost
-            # from the energy bin [E[iE], E[iE] + dE[iE]].
-
-            Ie_degraded .= (σ[i_level, iE] * min(1, E_levels[i_level, 1] / dE[iE])) .* Ie_scatter
-
-            # Find the energy bins where the e- in the current energy bin will degrade when
-            # losing E_levels[i_level, 1] eV
-            i_degrade = intersect(findall(x -> x > E[iE] - E_levels[i_level, 1], E + dE),      # find lowest bin
-                                  findall(x -> x < E[iE] + dE[iE] - E_levels[i_level, 1], E))  # find highest bin
-
-            partition_fraction = zeros(size(i_degrade)) # initialise
-            if !isempty(i_degrade) && i_degrade[1] < iE
-                # Distribute the degrading e- between those bins
-                partition_fraction[1] = min(1, (E[i_degrade[1]] .+ dE[i_degrade[1]] .-
-                                                E[iE] .+ E_levels[i_level, 1]) / dE[iE])
-                if length(i_degrade) > 2
-                    partition_fraction[2:end-1] = min.(1, dE[i_degrade[2:end-1]] / dE[iE])
-                end
-                partition_fraction[end] = min(1, (E[iE] .+ dE[iE] .- E[i_degrade[end]] .-
-                                                    E_levels[i_level, 1]) / dE[iE])
-                if i_degrade[end] == iE
-                    partition_fraction[end] = 0
-                end
-
-                # normalise
-                partition_fraction = partition_fraction / sum(partition_fraction)
-
-                # and finally calculate the flux of degrading e-
-                @tturbo for i_u in eachindex(findall(x -> x != 0, partition_fraction))
-                    for j in axes(Q, 2)
-                        for k in axes(Q, 1)
-                            Q[k, j, i_degrade[i_u]] +=  max(0, Ie_degraded[k, j]) * partition_fraction[i_u]
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-
-
-
-#################################################################################
-#                               Ionization collisions                           #
-#################################################################################
-
-
-
-
-
-function add_ionization_collisions!(Q, Ie, h_atm, t, n, σ, E_levels, cascading, E, dE, iE,
-                                    BeamWeight, μ_center)
-
-    Ionization = zeros(size(Ie, 1), size(Ie, 2))
-    Ionizing = Matrix{Float64}(undef, size(Ie, 1), size(Ie, 2))
-    n_repeated_over_μt = repeat(n, length(μ_center), length(t))
-    n_repeated_over_t = repeat(n, 1, length(t))
-
-    for i_level in axes(E_levels, 1)[2:end]
-        if E_levels[i_level, 2] > 0    # these collisions should produce secondary e-
-            # Find the energy bins where the e- in the current energy bin will degrade when
-            # losing E_levels[i_level, 1] eV
-            i_degrade = intersect(findall(x -> x > E[iE] - E_levels[i_level, 1], E + dE),     # find lowest bin
-                                  findall(x -> x < E[iE] + dE[iE] - E_levels[i_level,1], E))  # find highest bin
-
-            if !isempty(i_degrade) && i_degrade[1] < iE
-                # ISOTROPIC SECONDARY ELECTRONS
-
-                Ionizing .= n_repeated_over_μt .* (σ[i_level, iE] .* @view(Ie[:, :, iE]));
-                fill!(Ionization, 0)
-                @views for i_μ1 in eachindex(μ_center)
-                    for i_μ2 in eachindex(μ_center)
-                        Ionization[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
-                            max.(0, n_repeated_over_t .*
-                                (σ[i_level, iE] .*
-                                Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
-                                BeamWeight[i_μ1] ./ sum(BeamWeight))
-                    end
-                end
-
-                # Calculate the spectra of the secondary e-
-                secondary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "s");
-                # We use the average energy of the e- in the current energy bin
-                secondary_e_spectra = (secondary_e_spectra .+ secondary_e_spectra[[2:end; end]]) .* dE / 2
-
-                # Calculate the distribution of the ionizing (= primary) e-, that have lost the
-                # corresponding amount of energy
-                primary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "c");
-
-                if sum(secondary_e_spectra) > 0
-                    # normalise
-                    secondary_e_spectra = secondary_e_spectra ./ sum(secondary_e_spectra)
-                    # and multiply with the number of e- created
-                    secondary_e_spectra = E_levels[i_level, 2] .* secondary_e_spectra
-                end
-                if sum(primary_e_spectra) > 0
-                    # normalise
-                    primary_e_spectra = primary_e_spectra ./ sum(primary_e_spectra)
-                end
-
-                # and finally add this to the flux of degrading e-
-                @tturbo for iI in 1:(iE - 1)
-                    for j in axes(Q, 2)
-                        for k in axes(Q, 1)
-                            Q[k, j, iI] += Ionization[k, j] * secondary_e_spectra[iI] +
-                                           Ionizing[k, j] * primary_e_spectra[iI]
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-
-
-function prepare_ionization_collisions!(Ie, h_atm, t, n, σ, E_levels, cascading, E,
-                                              dE, iE, BeamWeight, μ_center,
-                                              Ionization_matrix, Ionizing_matrix,
-                                              secondary_vector, primary_vector,
-                                              counter_ionization)
-
-    Ionization = zeros(size(Ie, 1), size(Ie, 2))
-    Ionizing = Matrix{Float64}(undef, size(Ie, 1), size(Ie, 2))
-    n_repeated_over_μt = repeat(n, length(μ_center), length(t))
-    n_repeated_over_t = repeat(n, 1, length(t))
-
-    for i_level in axes(E_levels, 1)[2:end]
-        if E_levels[i_level, 2] > 0    # these collisions should produce secondary e-
-            # Find the energy bins where the e- in the current energy bin will degrade when
-            # losing E_levels[i_level, 1] eV
-            i_degrade = intersect(findall(x -> x > E[iE] - E_levels[i_level, 1], E + dE),     # find lowest bin
-                                  findall(x -> x < E[iE] + dE[iE] - E_levels[i_level,1], E))  # find highest bin
-
-            if !isempty(i_degrade) && i_degrade[1] < iE
-                # ISOTROPIC SECONDARY ELECTRONS
-
-                Ionizing .= n_repeated_over_μt .* (σ[i_level, iE] .* @view(Ie[:, :, iE]));
-                fill!(Ionization, 0)
-                @views for i_μ1 in eachindex(μ_center)
-                    for i_μ2 in eachindex(μ_center)
-                        Ionization[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
-                            max.(0, n_repeated_over_t .*
-                                (σ[i_level, iE] .*
-                                Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
-                                BeamWeight[i_μ1] ./ sum(BeamWeight))
-                    end
-                end
-
-                # Calculate the spectra of the secondary e-
-                secondary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "s");
-                # We use the average energy of the e- in the current energy bin
-                secondary_e_spectra = (secondary_e_spectra .+ secondary_e_spectra[[2:end; end]]) .* dE / 2
-
-                # Calculate the distribution of the ionizing (= primary) e-, that have lost the
-                # corresponding amount of energy
-                primary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "c");
-
-                if sum(secondary_e_spectra) > 0
-                    # normalise
-                    secondary_e_spectra = secondary_e_spectra ./ sum(secondary_e_spectra)
-                    # and multiply with the number of e- created
-                    secondary_e_spectra = E_levels[i_level, 2] .* secondary_e_spectra
-                end
-                if sum(primary_e_spectra) > 0
-                    # normalise
-                    primary_e_spectra = primary_e_spectra ./ sum(primary_e_spectra)
-                end
-
-                secondary_vector[counter_ionization[1]] .= secondary_e_spectra
-                primary_vector[counter_ionization[1]] .= primary_e_spectra
-                Ionization_matrix[counter_ionization[1]] .= Ionization
-                Ionizing_matrix[counter_ionization[1]] .= Ionizing
-            else
-                secondary_vector[counter_ionization[1]] .= 0
-                primary_vector[counter_ionization[1]] .= 0
-            end
-
-            counter_ionization[1] += 1
-        end
-    end
-end
-
-
-
-function add_ionization_collisions_batch!(Q, iE, Ionization_matrix, Ionizing_matrix,
-    secondary_vector, primary_vector)
-    # We need to add all the ionization collisions in three steps (15 different collisions
-    # split over groups of 5. This seems to be optimal on Revontuli)
-    for i_loop in 1:3
-        idx = (i_loop - 1) * 5
-        @tturbo for iI in 1:(iE - 1)
-            for j in axes(Q, 2)
-                for k in axes(Q, 1)
-                    Q[k, j, iI] += Ionization_matrix[idx + 1][k, j] * secondary_vector[idx + 1][iI] +
-                                    Ionizing_matrix[idx + 1][k, j] * primary_vector[idx + 1][iI] +
-                                    Ionization_matrix[idx + 2][k, j] * secondary_vector[idx + 2][iI] +
-                                    Ionizing_matrix[idx + 2][k, j] * primary_vector[idx + 2][iI] +
-                                    Ionization_matrix[idx + 3][k, j] * secondary_vector[idx + 3][iI] +
-                                    Ionizing_matrix[idx + 3][k, j] * primary_vector[idx + 3][iI] +
-                                    Ionization_matrix[idx + 4][k, j] * secondary_vector[idx + 4][iI] +
-                                    Ionizing_matrix[idx + 4][k, j] * primary_vector[idx + 4][iI] +
-                                    Ionization_matrix[idx + 5][k, j] * secondary_vector[idx + 5][iI] +
-                                    Ionizing_matrix[idx + 5][k, j] * primary_vector[idx + 5][iI]
-                end
-            end
-        end
-    end
-end
-
-
-
 
 
 #################################################################################
 #                                   Update Q                                    #
 #################################################################################
-
-
-
-
 
 function demo_update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                    B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, BeamWeight,
@@ -388,12 +84,307 @@ function update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_ne
 end
 
 
+
+
+
 #################################################################################
-#                                   Prototypes                                  #
+#                               Inelastic collisions                            #
+#################################################################################
+
+# legacy demo function
+function make_big_B2B_matrix(B2B_inelastic, n, h_atm)
+    idx1 = Vector{Int}(undef, 0)
+    idx2 = Vector{Int}(undef, 0)
+    aB2B = Vector{Float64}(undef, 0)
+    for i1 in axes(B2B_inelastic, 1)
+        for i2 in axes(B2B_inelastic, 2)
+            append!(idx1, (i1 - 1) * length(h_atm) .+ (1:length(h_atm)))
+            append!(idx2, (i2 - 1) * length(h_atm) .+ (1:length(h_atm)))
+            append!(aB2B, n * B2B_inelastic[i1, i2])
+        end
+    end
+    AB2B = sparse!(idx1, idx2, aB2B)
+    return AB2B
+end
+
+# New function, this is run one time (typically at first iteration of the energy loop) to
+# fully build the sparse B2B matrix
+function build_big_B2B(B2B_inelastic, n, h_atm)
+    n_elements = size(B2B_inelastic, 1) * size(B2B_inelastic, 2) * length(h_atm)
+    idx1 = Vector{Int}(undef, n_elements)
+    idx2 = Vector{Int}(undef, n_elements)
+    aB2B = Vector{Float64}(undef, n_elements)
+    counter = 1
+    for i1 in axes(B2B_inelastic, 1)
+        for i2 in axes(B2B_inelastic, 2)
+            idx_range = counter:(counter + length(h_atm) - 1)
+            idx1[idx_range] .= (i1 - 1) * length(h_atm) .+ (1:length(h_atm))
+            idx2[idx_range] .= (i2 - 1) * length(h_atm) .+ (1:length(h_atm))
+            aB2B[idx_range] .= n * B2B_inelastic[i1, i2]
+            counter += length(h_atm)
+        end
+    end
+
+    return sparse!(idx1, idx2, aB2B)
+end
+
+# New function, this is run every time we need to update the values in the B2B matrix (all
+# other iterations of the energy loop)
+# This was made possible after some trial and error to find out in what order the elements
+# of the B2B sparse matrix are stored in memory. Here we update these values in place.
+# What would'nt we do for better performance eh?
+function update_big_B2B!(AB2B, B2B_inelastic, n)
+    counter = 1
+    n_μ = size(B2B_inelastic, 2)
+    @views for i1 in axes(B2B_inelastic, 2)
+        for i2 in eachindex(n)
+            idx_range = counter:(counter + n_μ - 1)
+            AB2B.nzval[idx_range] .= n[i2] .* B2B_inelastic[:, i1]
+            counter += n_μ
+        end
+    end
+    return nothing
+end
+
+
+
+function add_inelastic_collisions!(Q, Ie, h_atm, n, σ, E_levels, B2B_inelastic, E, dE, iE, cache)
+    # Initialize
+    Ie_degraded = Matrix{Float64}(undef, size(Ie, 1), size(Ie, 2))
+
+    # Multiply each element of B2B with n (density vector) and resize to get a matrix that
+    # can be multiplied with Ie
+    if iE == length(E)
+        # build the matrix the first time
+        cache.AB2B = build_big_B2B(B2B_inelastic, n, h_atm)
+    else
+        # then reuse the sparse structure and just update the values
+        update_big_B2B!(cache.AB2B, B2B_inelastic, n)
+    end
+
+    # Then calculate the flux of electrons that scatter
+    Ie_scatter = cache.AB2B * @view(Ie[:, :, iE])
+
+    # Loop over the energy levels of the collisions with the i-th neutral species
+    for i_level in axes(E_levels, 1)[2:end]
+        if E_levels[i_level, 2] <= 0  # these collisions should not produce secondary e-
+            # The flux of e- degraded from energy bin [E[iE], E[iE] + dE[iE]] to any lower
+            # energy bin by excitation of the E_levels[i_level] state of the current
+            # species. The second factor corrects for the case where the energy loss is
+            # smaller than the width in energy of the energy bin. That is, when dE[iE] >
+            # E_levels[i_level,1], only the fraction E_levels[i_level,1] / dE[iE] is lost
+            # from the energy bin [E[iE], E[iE] + dE[iE]].
+
+            Ie_degraded .= (σ[i_level, iE] * min(1, E_levels[i_level, 1] / dE[iE])) .* Ie_scatter
+
+            # Find the energy bins where the e- in the current energy bin will degrade when
+            # losing E_levels[i_level, 1] eV
+            i_degrade = intersect(findall(x -> x > E[iE] - E_levels[i_level, 1], E + dE),      # find lowest bin
+                                  findall(x -> x < E[iE] + dE[iE] - E_levels[i_level, 1], E))  # find highest bin
+
+            partition_fraction = zeros(size(i_degrade)) # initialise
+            if !isempty(i_degrade) && i_degrade[1] < iE
+                # Distribute the degrading e- between those bins
+                partition_fraction[1] = min(1, (E[i_degrade[1]] .+ dE[i_degrade[1]] .-
+                                                E[iE] .+ E_levels[i_level, 1]) / dE[iE])
+                if length(i_degrade) > 2
+                    partition_fraction[2:end-1] = min.(1, dE[i_degrade[2:end-1]] / dE[iE])
+                end
+                partition_fraction[end] = min(1, (E[iE] .+ dE[iE] .- E[i_degrade[end]] .-
+                                                    E_levels[i_level, 1]) / dE[iE])
+                if i_degrade[end] == iE
+                    partition_fraction[end] = 0
+                end
+
+                # normalise
+                partition_fraction = partition_fraction / sum(partition_fraction)
+
+                # and finally calculate the flux of degrading e-
+                @tturbo for i_u in eachindex(findall(x -> x != 0, partition_fraction))
+                    for j in axes(Q, 2)
+                        for k in axes(Q, 1)
+                            Q[k, j, i_degrade[i_u]] +=  max(0, Ie_degraded[k, j]) * partition_fraction[i_u]
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+
+
+#################################################################################
+#                               Ionization collisions                           #
 #################################################################################
 
 
 
+
+#=
+This is kind of the demo function for the ionization (legacy).
+For a given energy E and a neutral species n, this function does the following:
+
+1. Loop over the ionization collisions of the current neutral species n
+2. For each ionization collision, calculate the ionization matrix and ionizing matrix
+3. For each ionization collision, calculate the secondary_e_spectra vector and primary_e_spectra vector
+4. Add everything to Q
+
+Let's review the different elements:
+
+## Ionization matrix, shape (n_μ x n_z, n_μ x n_z)
+It is the flux of secondary electrons. It is calculated as the product of the density of the
+neutral species, the cross-section of the current ionization collision, and the electron
+flux at the current energy. It is also redristibuted isotropically over the different angles.
+A simplified calculation looks like this:
+    Ionization_matrix = n * σ * Ie[:, :, iE]    (no isotropic redistribution here)
+
+## Ionizing matrix, shape (n_μ x n_z, n_μ x n_z)
+It is the flux of primary electrons. It is calculated as the product of the density of the
+neutral species, the cross-section of the current ionization collision, and the electron
+flux at the current energy. The difference with the flux of secondary electron (Ionization
+matrix) is that it is not redistributed (the primary electrons continue to propagate with
+the same pitch-angle as before).
+A simplified calculation looks like this:
+    Ionizing_matrix = n * σ * Ie[:, :, iE]
+
+## secondary_e_spectra and primary_e_spectra vectors, both of shape (nE)
+These are calculated using the very fancy `cascading` function. The function calculates how
+the secondary and degraded primary electrons will be distributed in energy after the collision.
+They are scaled so that sum(secondary_e_spectra) = number_of_secondaries (1 or 2 depending
+on the collision) and sum(primary_e_spectra) = 1.
+
+
+The (Ionization matrix + secondary_e_spectra) and the (Ionizing matrix + primary_e_spectra)
+form two pairs. The first is used to calculate the final secondary electrons that will be
+created at lower energies, and the second one to calculate the final primary electrons that
+will be degraded in energy.
+
+These pairs are added to Q using a for loop of the following form
+
+```julia
+for iI in 1:(iE - 1)
+    for j in axes(Q, 2)
+        for k in axes(Q, 1)
+            Q[k, j, iI] += Ionization[k, j] * secondary_e_spectra[iI] +
+                            Ionizing[k, j] * primary_e_spectra[iI]
+        end
+    end
+end
+```
+=#
+function add_ionization_collisions!(Q, Ie, h_atm, t, n, σ, E_levels, cascading, E, dE, iE,
+                                    BeamWeight, μ_center)
+
+    Ionization = zeros(size(Ie, 1), size(Ie, 2))
+    Ionizing = Matrix{Float64}(undef, size(Ie, 1), size(Ie, 2))
+    n_repeated_over_μt = repeat(n, length(μ_center), length(t))
+    n_repeated_over_t = repeat(n, 1, length(t))
+
+    for i_level in axes(E_levels, 1)[2:end]
+        if E_levels[i_level, 2] > 0    # these collisions should produce secondary e-
+            # Find the energy bins where the e- in the current energy bin will degrade when
+            # losing E_levels[i_level, 1] eV
+            i_degrade = intersect(findall(x -> x > E[iE] - E_levels[i_level, 1], E + dE),     # find lowest bin
+                                  findall(x -> x < E[iE] + dE[iE] - E_levels[i_level,1], E))  # find highest bin
+
+            if !isempty(i_degrade) && i_degrade[1] < iE
+                # ISOTROPIC SECONDARY ELECTRONS
+
+                Ionizing .= n_repeated_over_μt .* (σ[i_level, iE] .* @view(Ie[:, :, iE]));
+                fill!(Ionization, 0)
+                @views for i_μ1 in eachindex(μ_center)
+                    for i_μ2 in eachindex(μ_center)
+                        Ionization[(i_μ1 - 1) * length(h_atm) .+ (1:length(h_atm)), :] .+=
+                            max.(0, n_repeated_over_t .*
+                                (σ[i_level, iE] .*
+                                Ie[(i_μ2 - 1) * length(h_atm) .+ (1:length(h_atm)), :, iE]) .*
+                                BeamWeight[i_μ1] ./ sum(BeamWeight))
+                    end
+                end
+
+                # Calculate the spectra of the secondary e-
+                secondary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "s");
+                # We use the average energy of the e- in the current energy bin
+                secondary_e_spectra = (secondary_e_spectra .+ secondary_e_spectra[[2:end; end]]) .* dE / 2
+
+                # Calculate the distribution of the ionizing (= primary) e-, that have lost the
+                # corresponding amount of energy
+                primary_e_spectra = cascading(E, E[iE], E_levels[i_level, 1], "c");
+
+                if sum(secondary_e_spectra) > 0
+                    # normalise
+                    secondary_e_spectra = secondary_e_spectra ./ sum(secondary_e_spectra)
+                    # and multiply with the number of e- created
+                    secondary_e_spectra = E_levels[i_level, 2] .* secondary_e_spectra
+                end
+                if sum(primary_e_spectra) > 0
+                    # normalise
+                    primary_e_spectra = primary_e_spectra ./ sum(primary_e_spectra)
+                end
+
+                # and finally add this to the flux of degrading e-
+                @tturbo for iI in 1:(iE - 1)
+                    for j in axes(Q, 2)
+                        for k in axes(Q, 1)
+                            Q[k, j, iI] += Ionization[k, j] * secondary_e_spectra[iI] +
+                                           Ionizing[k, j] * primary_e_spectra[iI]
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+#=
+The three following functions do the same thing as the function above, but in a much more
+efficient way.
+
+This refactoring is based on the fact that for a given neutral species n, the only variables
+that are changing with each ionization collision are the cross-section of the collision σ and
+the secondary_e_spectra and primary_e_spectra vectors. The rest of the calculation is the
+same for all ionization collisions of the same neutral species.
+Hence, we can split the ionization calculation into two parts:
+- one that is the same for all ionization of the same neutral species
+- one that is different for each ionization collision.
+This change introduces the possibility to do some factorization and greatly reduce the
+number of calculations and array memory access. Let see more in details how this works.
+
+In this new version, we have *for each neutral species*,
+1. The Ionization_fragment_1, which by analogy to the Ionization_matrix example, is equal to
+    Ionization_fragment_1 = n * Ie[:, :, iE]    (no isotropic redistribution here)
+2. The Ionizing_fragment_1, which by analogy to the Ionizing_matrix example, is equal to
+    Ionizing_fragment_1 = n * Ie[:, :, iE]
+These are calculated using the `prepare_first_ionization_fragment!()` function.
+
+3. The Ionization_fragment_2, which is equal to
+    Ionization_fragment_2 = ∑ secondary_e_spectra[i_level] .* σ[i_level]
+    where the sum is done over the ionization collisions of the current neutral species
+4. The Ionizing_fragment_2, which is equal to
+    Ionizing_fragment_2 = ∑ primary_e_spectra[i_level] .* σ[i_level]
+    where the sum is done over the ionization collisions of the current neutral species
+These are calculated using the `prepare_second_ionization_fragment!()` function. This is
+where the sweet factorization happens.
+
+Then we are simply able to add the fragments to Q using the following loop (from the
+function `add_ionization_fragments!()`), which needs to be run only once for the current energy.
+```julia
+for iI in 1:(iE - 1)
+    for j in axes(Q, 2)
+        for k in axes(Q, 1)
+            Q[k, j, iI] += Ionization_fragment_1[1][k, j] * Ionization_fragment_2[1][iI] +  # secondaries of species 1
+                            Ionization_fragment_1[2][k, j] * Ionization_fragment_2[2][iI] +  # secondaries of species 2
+                            Ionization_fragment_1[3][k, j] * Ionization_fragment_2[3][iI] +  # secondaries of species 3
+                            Ionizing_fragment_1[1][k, j] * Ionizing_fragment_2[1][iI] +  # primaries of species 1
+                            Ionizing_fragment_1[2][k, j] * Ionizing_fragment_2[2][iI] +  # primaries of species 2
+                            Ionizing_fragment_1[3][k, j] * Ionizing_fragment_2[3][iI]    # primaries of species 3
+        end
+    end
+end
+```
+=#
 function prepare_first_ionization_fragment!(Ionization_fragment_1, Ionizing_fragment_1,
                                             n, Ie, t, h_atm, μ_center, BeamWeight, iE)
     n_repeated_over_μt = repeat(n, length(μ_center), length(t))

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -362,6 +362,7 @@ function update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_ne
 
         add_inelastic_collisions!(Q, Ie, h_atm, n, σ, E_levels, B2B_inelastic, E, dE, iE, cache)
 
+        # TODO: that's if I will move things outside of the energy loop
         # fill!(Ionization_fragment_1[i], 0)
         # fill!(Ionizing_fragment_1[i], 0)
         # fill!(Ionization_fragment_2[i], 0)
@@ -376,9 +377,14 @@ function update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_ne
                                     σ, E_levels, cascading, E, dE, iE)
         end
     end
-    add_ionization_fragments!(Q, iE,
-                              Ionization_fragment_1, Ionizing_fragment_1,
-                              Ionization_fragment_2, Ionizing_fragment_2)
+    # If there is no ionization to add (everything is zero), skip the update of Q
+    # Mmh the compiler seems to be smart enough to skip the update of Q anyway when
+    # everything is zero. But let's keep this if statement just in case.
+    if !(iszero(Ionization_fragment_2) && iszero(Ionizing_fragment_2))
+        add_ionization_fragments!(Q, iE,
+                                  Ionization_fragment_1, Ionizing_fragment_1,
+                                  Ionization_fragment_2, Ionizing_fragment_2)
+    end
 end
 
 

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -219,9 +219,6 @@ end
 #                               Ionization collisions                           #
 #################################################################################
 
-
-
-
 #=
 This is kind of the demo function for the ionization (legacy).
 For a given energy E and a neutral species n, this function does the following:
@@ -337,6 +334,8 @@ function add_ionization_collisions!(Q, Ie, h_atm, t, n, σ, E_levels, cascading,
         end
     end
 end
+
+
 
 #=
 The three following functions do the same thing as the function above, but in a much more

--- a/src/energy_degradation.jl
+++ b/src/energy_degradation.jl
@@ -19,8 +19,25 @@ function make_big_B2B_matrix(B2B_inelastic, n, h_atm)
     return AB2B
 end
 
+function make_big_B2B_matrix_new(B2B_inelastic, n, h_atm)
+    n_elements = size(B2B_inelastic, 1) * size(B2B_inelastic, 2) * length(h_atm)
+    idx1 = Vector{Int}(undef, n_elements)
+    idx2 = Vector{Int}(undef, n_elements)
+    aB2B = Vector{Float64}(undef, n_elements)
 
+    counter = 1
+    for i1 in axes(B2B_inelastic, 1)
+        for i2 in axes(B2B_inelastic, 2)
+            idx_range = counter:(counter + length(h_atm) - 1)
+            idx1[idx_range] .= (i1 - 1) * length(h_atm) .+ (1:length(h_atm))
+            idx2[idx_range] .= (i2 - 1) * length(h_atm) .+ (1:length(h_atm))
+            aB2B[idx_range] .= n * B2B_inelastic[i1, i2]
+            counter += length(h_atm)
+        end
+    end
 
+    return sparse!(idx1, idx2, aB2B)
+end
 
 
 #################################################################################
@@ -36,7 +53,7 @@ function add_inelastic_collisions!(Q, Ie, h_atm, n, σ, E_levels, B2B_inelastic,
 
     # Multiply each element of B2B with n (density vector) and resize to get a matrix that
     # can be multiplied with Ie
-    AB2B =  make_big_B2B_matrix(B2B_inelastic, n, h_atm)
+    AB2B =  make_big_B2B_matrix_new(B2B_inelastic, n, h_atm)
     Ie_scatter = AB2B * @view(Ie[:, :, iE])
 
     # Loop over the energy levels of the collisions with the i-th neutral species

--- a/src/main.jl
+++ b/src/main.jl
@@ -7,8 +7,6 @@ using KLU: KLU, klu
 
 # Practical cache storage
 mutable struct Cache
-    # AB2B
-    # KLU_cache
     AB2B::SparseArrays.SparseMatrixCSC{Float64, Int64}
     KLU::KLU.KLUFactorization{Float64, Int64}
 end
@@ -70,7 +68,6 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
     ## Initialize cache
-    # cache = Cache(nothing, nothing)
     cache = Cache()
 
     ## Precalculate the B2B fragment
@@ -105,17 +102,11 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
                                                          Ie_top_local[:, :, iE], I0[:, iE],
                                                          cache)
             end
-            # Ie[:, :, iE] = Crank_Nicolson_old(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
-            #                                              A, B, D[iE, :], Q[:, :, iE],
-            #                                              Ie_top_local[:, :, iE], I0[:, iE])
 
             # Update the cascading of e-
             update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                         B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
                         μ_center, cache)
-            # demo_update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
-            #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
-            #             μ_center, cache)
 
             next!(p)
         end
@@ -181,7 +172,6 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
     ## Initialize cache
-    # cache = Cache(nothing, nothing)
     cache = Cache()
 
     ## Precalculate the B2B fragment

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,6 +1,12 @@
 using Dates: Dates, now
 using ProgressMeter: Progress, next!
+using SparseArrays: spzeros, SparseMatrixCSC
 using Term: @bold
+
+# Practical cache storage
+mutable struct Cache
+    AB2B::SparseMatrixCSC{Float64,Int64}
+end
 
 function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith, t_sampling,
     n_loop, msis_file, iri_file, savedir, INPUT_OPTIONS, CFL_number = 64)
@@ -58,6 +64,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
     # secondary_vector = [zeros(length(E)) for _ in 1:15]
     # primary_vector = [zeros(length(E)) for _ in 1:15]
     KLU_cache = []
+    cache = Cache(spzeros(1, 1))
 
     ## Precalculate the B2B fragment
     B2B_fragment = prepare_beams2beams(μ_scatterings.BeamWeight_relative, μ_scatterings.Pmu2mup);
@@ -95,10 +102,10 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
             # update_Q_turbo!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
             #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE,
             #             μ_scatterings.BeamWeight, μ_center,
-            #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector)
+            #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector, cache)
             new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                         B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
-                        μ_center)
+                        μ_center, cache)
 
             next!(p)
         end
@@ -169,6 +176,7 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
     # secondary_vector = [zeros(length(E)) for _ in 1:15]
     # primary_vector = [zeros(length(E)) for _ in 1:15]
     KLU_cache = []
+    cache = Cache(spzeros(1, 1))
 
     ## Precalculate the B2B fragment
     B2B_fragment = prepare_beams2beams(μ_scatterings.BeamWeight_relative, μ_scatterings.Pmu2mup);
@@ -208,10 +216,10 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
         # Update the cascading of e-
         # update_Q_turbo!(Q, Ie, h_atm, 1:1:1, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals, B2B_inelastic_neutrals,
         #             cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight, μ_center,
-        #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector)
+        #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector, cache)
         new_Q!(Q, Ie, h_atm, 1:1:1, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                   B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
-                  μ_center)
+                  μ_center, cache)
 
         next!(p)
     end

--- a/src/main.jl
+++ b/src/main.jl
@@ -94,19 +94,26 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
                                                 phase_fcn_neutrals, dE, iE, B2B_fragment, μ_scatterings.theta1);
 
             # Compute the flux of e-
-            if iE == length(E)
-                Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+            # if iE == length(E)
+            #     Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+            #                                              A, B, D[iE, :], Q[:, :, iE],
+            #                                              Ie_top_local[:, :, iE], I0[:, iE],
+            #                                              cache, first_iteration = true)
+            # else
+            #     Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+            #                                              A, B, D[iE, :], Q[:, :, iE],
+            #                                              Ie_top_local[:, :, iE], I0[:, iE],
+            #                                              cache)
+            # end
+            Ie[:, :, iE] = Crank_Nicolson_old(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
                                                          A, B, D[iE, :], Q[:, :, iE],
-                                                         Ie_top_local[:, :, iE], I0[:, iE],
-                                                         cache, first_iteration = true)
-            else
-                Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
-                                                         A, B, D[iE, :], Q[:, :, iE],
-                                                         Ie_top_local[:, :, iE], I0[:, iE],
-                                                         cache)
-            end
+                                                         Ie_top_local[:, :, iE], I0[:, iE])
+
             # Update the cascading of e-
-            update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+            # update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+            #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
+            #             μ_center, cache)
+            demo_update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                         B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
                         μ_center, cache)
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -17,7 +17,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
     # the results are correct. Here we check the CFL criteria and reduce the time grid
     # accordingly
     t, CFL_factor = CFL_criteria(t_sampling, h_atm, v_of_E(E_max), CFL_number)
-    # TODO: fix properly the time sampling of incoming data from file
+    # TODO: fix properly the time sampling of incoming data from file   # What did I mean here?? /EG20250504
 
     ## Load incoming flux
     if INPUT_OPTIONS.input_type == "from_old_matlab_file"
@@ -50,7 +50,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
         CFL_number, INPUT_OPTIONS, savedir)
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
-    # Initialize arrays for the ionization collisions part of the energy degradation
+    ## Initialize arrays for the ionization collisions part of the energy degradation
     Ionization_matrix = [zeros(length(h_atm) * length(μ_center), length(t)) for _ in 1:15]
     Ionizing_matrix = [zeros(length(h_atm) * length(μ_center), length(t)) for _ in 1:15]
     secondary_vector = [zeros(length(E)) for _ in 1:15]
@@ -147,7 +147,7 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
         0, INPUT_OPTIONS, savedir)
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
-    # Initialize arrays for the ionization collisions part of the energy degradation
+    ## Initialize arrays for the ionization collisions part of the energy degradation
     Ionization_matrix = [zeros(length(h_atm) * length(μ_center), 1) for _ in 1:15]
     Ionizing_matrix = [zeros(length(h_atm) * length(μ_center), 1) for _ in 1:15]
     secondary_vector = [zeros(length(E)) for _ in 1:15]

--- a/src/main.jl
+++ b/src/main.jl
@@ -94,28 +94,28 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
                                                 phase_fcn_neutrals, dE, iE, B2B_fragment, μ_scatterings.theta1);
 
             # Compute the flux of e-
-            # if iE == length(E)
-            #     Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
-            #                                              A, B, D[iE, :], Q[:, :, iE],
-            #                                              Ie_top_local[:, :, iE], I0[:, iE],
-            #                                              cache, first_iteration = true)
-            # else
-            #     Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
-            #                                              A, B, D[iE, :], Q[:, :, iE],
-            #                                              Ie_top_local[:, :, iE], I0[:, iE],
-            #                                              cache)
-            # end
-            Ie[:, :, iE] = Crank_Nicolson_old(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+            if iE == length(E)
+                Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
                                                          A, B, D[iE, :], Q[:, :, iE],
-                                                         Ie_top_local[:, :, iE], I0[:, iE])
+                                                         Ie_top_local[:, :, iE], I0[:, iE],
+                                                         cache, first_iteration = true)
+            else
+                Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+                                                         A, B, D[iE, :], Q[:, :, iE],
+                                                         Ie_top_local[:, :, iE], I0[:, iE],
+                                                         cache)
+            end
+            # Ie[:, :, iE] = Crank_Nicolson_old(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
+            #                                              A, B, D[iE, :], Q[:, :, iE],
+            #                                              Ie_top_local[:, :, iE], I0[:, iE])
 
             # Update the cascading of e-
-            # update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
-            #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
-            #             μ_center, cache)
-            demo_update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+            update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                         B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
                         μ_center, cache)
+            # demo_update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+            #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
+            #             μ_center, cache)
 
             next!(p)
         end

--- a/src/main.jl
+++ b/src/main.jl
@@ -58,11 +58,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
         CFL_number, INPUT_OPTIONS, savedir)
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
-    ## Initialize arrays for the ionization collisions part of the energy degradation
-    # Ionization_matrix = [zeros(length(h_atm) * length(μ_center), length(t)) for _ in 1:15]
-    # Ionizing_matrix = [zeros(length(h_atm) * length(μ_center), length(t)) for _ in 1:15]
-    # secondary_vector = [zeros(length(E)) for _ in 1:15]
-    # primary_vector = [zeros(length(E)) for _ in 1:15]
+    ## Initialize cache
     KLU_cache = []
     cache = Cache(spzeros(1, 1))
 
@@ -91,7 +87,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
                 Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
                                                          A, B, D[iE, :], Q[:, :, iE],
                                                          Ie_top_local[:, :, iE], I0[:, iE],
-                                                         [], first_iteration = true)
+                                                         KLU_cache, first_iteration = true)
             else
                 Ie[:, :, iE] = Crank_Nicolson(t, h_atm ./ cosd(B_angle_to_zenith), μ_center, v_of_E(E[iE]),
                                                          A, B, D[iE, :], Q[:, :, iE],
@@ -99,11 +95,7 @@ function calculate_e_transport(altitude_lims, θ_lims, E_max, B_angle_to_zenith,
                                                          KLU_cache)
             end
             # Update the cascading of e-
-            # update_Q_turbo!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
-            #             B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE,
-            #             μ_scatterings.BeamWeight, μ_center,
-            #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector, cache)
-            new_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+            update_Q!(Q, Ie, h_atm, t, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                         B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
                         μ_center, cache)
 
@@ -170,11 +162,7 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
         0, INPUT_OPTIONS, savedir)
     save_neutrals(h_atm, n_neutrals, ne, Te, Tn, savedir)
 
-    ## Initialize arrays for the ionization collisions part of the energy degradation
-    # Ionization_matrix = [zeros(length(h_atm) * length(μ_center), 1) for _ in 1:15]
-    # Ionizing_matrix = [zeros(length(h_atm) * length(μ_center), 1) for _ in 1:15]
-    # secondary_vector = [zeros(length(E)) for _ in 1:15]
-    # primary_vector = [zeros(length(E)) for _ in 1:15]
+    ## Initialize cache
     KLU_cache = []
     cache = Cache(spzeros(1, 1))
 
@@ -209,15 +197,9 @@ function calculate_e_transport_steady_state(altitude_lims, θ_lims, E_max, B_ang
                                                A, B, D[iE, :], Q[:, 1, iE],
                                                Ie_top_local[:, iE], KLU_cache)
         end
-        # Ie[:, 1, iE] = steady_state_scheme_old(h_atm ./ cosd(B_angle_to_zenith),
-        #                                                   μ_center, A, B, D[iE, :],
-        #                                                   Q[:, 1, iE], Ie_top_local[:, iE])
 
         # Update the cascading of e-
-        # update_Q_turbo!(Q, Ie, h_atm, 1:1:1, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals, B2B_inelastic_neutrals,
-        #             cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight, μ_center,
-        #             Ionization_matrix, Ionizing_matrix, secondary_vector, primary_vector, cache)
-        new_Q!(Q, Ie, h_atm, 1:1:1, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
+        update_Q!(Q, Ie, h_atm, 1:1:1, ne, Te, n_neutrals, σ_neutrals, E_levels_neutrals,
                   B2B_inelastic_neutrals, cascading_neutrals, E, dE, iE, μ_scatterings.BeamWeight,
                   μ_center, cache)
 

--- a/src/matrix_building.jl
+++ b/src/matrix_building.jl
@@ -113,8 +113,7 @@ function make_B(n_neutrals, σ_neutrals, E_levels_neutrals, phase_fcn_neutrals, 
             end
         end
 
-        # Save the inelastic B2B matrices for the future energy degradations (update of Q)
-        # calculations
+        # Save the inelastic B2B matrices for the future energy degradations (updates of Q)
         B2B_inelastic_neutrals[i] = copy(B2B_inelastic);
     end
     return B, B2B_inelastic_neutrals

--- a/src/phase_functions.jl
+++ b/src/phase_functions.jl
@@ -275,8 +275,9 @@ function convert_phase_fcn_to_3D!(phase_fcn, θ)
     # scatter on a "ring" (think about a slice of a sphere) of area 2π*sin(θ)*dθ. This means that the
     # probability of scattering will be underestimated the more we approach angles around 90°. This
     # function is here to correct that.
-    phase_fcn = phase_fcn .* abs.(sin.(θ));       # we don't need the factors 2π and dθ as they are the same for all theta bins.
+    phase_fcn = phase_fcn .* abs.(sin.(θ));     # we don't need the factors 2π and dθ as they are the same for all theta bins.
     phase_fcn = phase_fcn ./ sum(phase_fcn);    # so that sum of probabilities = 1
+    return nothing
 end
 
 function convert_phase_fcn_to_3D(phase_fcn, θ)
@@ -286,7 +287,7 @@ function convert_phase_fcn_to_3D(phase_fcn, θ)
     # scatter on a "ring" (think about a slice of a sphere) of area 2π*sin(θ)*dθ. This means that the
     # probability of scattering will be underestimated the more we approach angles around 90°. This
     # function is here to correct that.
-    phase_fcn = phase_fcn .* abs.(sin.(θ));       # we don't need the factors 2π and dθ as they are the same for all theta bins.
+    phase_fcn = phase_fcn .* abs.(sin.(θ));     # we don't need the factors 2π and dθ as they are the same for all theta bins.
     phase_fcn = phase_fcn ./ sum(phase_fcn);    # so that sum of probabilities = 1
     return phase_fcn
 end

--- a/src/steady_state.jl
+++ b/src/steady_state.jl
@@ -1,8 +1,8 @@
-using KLU: klu
+using KLU: klu, klu!
 using LinearAlgebra: Diagonal
 using SparseArrays: spdiagm, sparse, dropzeros!, findnz
 
-function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top)
+function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top, KLU_cache; first_iteration = false)
     Ie = Array{Float64}(undef, length(h_atm) * length(μ))
 
     # Spatial differentiation matrices, for up and down streams
@@ -64,20 +64,104 @@ function steady_state_scheme(h_atm, μ, A, B, D, Q, Ie_top)
             end
         end
     end
-    Mlhs = sparse(row_l, col_l, val_l)
-    dropzeros!(Mlhs)    # for the performance of the next calculations
+    Mlhs = sparse!(row_l, col_l, val_l)
+    dropzeros!(Mlhs)    # for performance
 
     index_top_bottom = sort(vcat(1:length(h_atm):(length(μ)*length(h_atm)),
                             length(h_atm):length(h_atm):(length(μ)*length(h_atm))))
 
-    AAA = klu(Mlhs)
+    if first_iteration
+        global KLU_cache = klu(Mlhs)
+    else
+        klu!(KLU_cache, Mlhs)
+    end
 
     I_top_bottom = (Ie_top * [0, 1]')'
     Q_local = copy(Q)
     Q_local[index_top_bottom] = I_top_bottom[:]
-    Ie = AAA \ Q_local
-
+    Ie = KLU_cache \ Q_local
 
     Ie[Ie .< 0] .= 0; # the fluxes should never be negative
+
+    return Ie
+end
+
+function steady_state_scheme_old(h_atm, μ, A, B, D, Q, Ie_top)
+    Ie = Array{Float64}(undef, length(h_atm) * length(μ))
+
+    # Spatial differentiation matrices, for up and down streams
+    # Here we tuck on a fictious height one tick below lowest height and on tick above highest
+    # height just to make it possible to use the diff function.
+    h4diffu = [h_atm[1] - (h_atm[2] - h_atm[1]) ; h_atm]
+    h4diffd = [h_atm ; h_atm[end] + (h_atm[end] - h_atm[end-1])]
+    Ddz_Up   = spdiagm(-1 => -1 ./ diff(h4diffu[2:end]),
+                        0 =>  1 ./ diff(h4diffu[1:end]))
+    Ddz_Down = spdiagm( 0 => -1 ./ diff(h4diffd[1:end]),
+                        1 =>  1 ./ diff(h4diffd[1:end-1]))
+
+    # Diffusion operator
+    Ddiffusion = d2M(h_atm)
+    Ddiffusion[1, 1] = 0
+
+    # Building the CN matrices
+    Nz = length(h_atm)
+    row_l = Vector{Int64}() # maybe using sizehint could help?
+    col_l = Vector{Int64}()
+    val_l = Vector{Float64}()
+    for i1 in axes(B, 2)
+        for i2 in axes(B, 2)
+            A_tmp = A
+            B_tmp = B[:, i1, i2]
+            # if μ[i1] < 0    # downward fluxes
+            #     A_tmp = (A .+ A[[2:end; end]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[2:end; end], i1, i2]) ./ 2
+            # else            # upward fluxes
+            #     A_tmp = (A .+ A[[1; 1:end-1]]) ./ 2
+            #     B_tmp = (B[:, i1, i2] .+ B[[1; 1:end-1], i1, i2]) ./ 2
+            # end
+            if i1 != i2
+                tmp_lhs = -B_tmp
+                tmp_lhs[1] = tmp_lhs[end] = 0
+
+                idx_row = (i1 - 1) * Nz .+ (1:Nz)
+                idx_col = (i2 - 1) * Nz .+ (1:Nz)
+                append!(row_l, idx_row)
+                append!(col_l, idx_col)
+                append!(val_l, tmp_lhs)
+            else
+                if μ[i1] < 0    # downward fluxes
+                    tmp_lhs =   μ[i1] .* Ddz_Down .+ Diagonal(A_tmp) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp)
+                    tmp_lhs[[1, end], :] .= 0
+                    tmp_lhs[end, end] = 1
+                else            # upward fluxes
+                    tmp_lhs =   μ[i1] .* Ddz_Up .+ Diagonal(A_tmp) .- D[i1] .* Ddiffusion .+ Diagonal(-B_tmp)
+                    tmp_lhs[[1, end], :] .= 0
+                    tmp_lhs[end, end-1:end] = [-1, 1]
+                end
+                tmp_lhs[1, 1] = 1
+
+                idx_row = (i1 - 1) * Nz .+ findnz(tmp_lhs)[1]
+                idx_col = (i2 - 1) * Nz .+ findnz(tmp_lhs)[2]
+                append!(row_l, idx_row)
+                append!(col_l, idx_col)
+                append!(val_l, findnz(tmp_lhs)[3])
+            end
+        end
+    end
+    Mlhs = sparse!(row_l, col_l, val_l)
+    dropzeros!(Mlhs)    # for performance
+
+    index_top_bottom = sort(vcat(1:length(h_atm):(length(μ)*length(h_atm)),
+                            length(h_atm):length(h_atm):(length(μ)*length(h_atm))))
+
+    KLU_cache = klu(Mlhs)
+
+    I_top_bottom = (Ie_top * [0, 1]')'
+    Q_local = copy(Q)
+    Q_local[index_top_bottom] = I_top_bottom[:]
+    Ie = KLU_cache \ Q_local
+
+    Ie[Ie .< 0] .= 0; # the fluxes should never be negative
+
     return Ie
 end


### PR DESCRIPTION
- Rework the energy degradation to reduce the number of calculations (most of the runtime reduction comes from this)
- Rework the construction of the B matrix
- Rework the construction of the sparse B2B matrix
- Use buffers for the klu factorization in the Crank-Nicholson and steady state schemes

The result is that the code is around 3x faster to run, both for time-dependent and steady-state simulations.

## TODO
- [x] add an entry in CHANGELOG.md
- [x] clean stuff
- [x] document changes in the code
