### PR TITLE
Increase possible maximum energy and add error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-
+- Push possible maximum energy [#67](https://github.com/egavazzi/AURORA.jl/pull/67)
 - Improved performances, making simulations around 3x faster to run [#64](https://github.com/egavazzi/AURORA.jl/pull/64)
 
 ## v0.5.0 - 2025-05-01

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -102,8 +102,11 @@ Create an energy grid based on the maximum energy `E_max` given as input.
 - `dE`: energy bin sizes(eV). Vector [nE]
 """
 function make_energy_grid(E_max)
+    if E_max > 1e6
+        error("AURORA does not support energies above 1 MeV. Please use a lower value for E_max.")
+    end
     E_function(X, dE_initial, dE_final, C, X0) = dE_initial + (1 + tanh(C * (X - X0))) / 2 * dE_final
-    E = cumsum(E_function.(0:4000, 0.15, 11.5, 0.05, 80)) .+ 1.9
+    E = cumsum(E_function.(0:100000, 0.15, 11.5, 0.05, 80)) .+ 1.9
     iE_max = findmin(abs.(E .- E_max))[2];  # find the index for the upper limit of the energy grid
     E = E[1:iE_max];                        # crop E accordingly
     dE = diff(E); dE = [dE; dE[end]]


### PR DESCRIPTION
The current version of the code cannot generate points in the E_grid with energies greater than 45687eV. However, it is not throwing any error and silently produces wrong results when used in combination with some of the top flux generation functions (like ridiculously high ionization rates).

See following figure of the ionization rate for constant precipitation at different energies, steady-state simulations (credits: @ostald). The ionization rate skyrockets for E_max above ~45 keV.
<img width="596" height="447" alt="Screenshot 2025-08-22 at 13 40 16" src="https://github.com/user-attachments/assets/3b54e2c4-8e56-4891-aa24-94a6f73d8727" />


This PR pushes the maximum energy grid to 1 MeV and throws an error if some `E_max` greater than this is given as input. Realistically, running the time-dependent version with an E_max of 1 MeV would take a ridiculously long time and we would have to take into account relativistic effects (probably).

## TODO
- [x] add an entry in CHANGELOG.md
