### PR TITLE
Fix densities at low altitudes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
-- Push possible maximum energy [#67](https://github.com/egavazzi/AURORA.jl/pull/67)
-- Improved performances, making simulations around 3x faster to run [#64](https://github.com/egavazzi/AURORA.jl/pull/64)
-- Faster scattering calculations, can change results very slightly [#66](https://github.com/egavazzi/AURORA.jl/pull/66)
+- Fix negative densities at very low altitudes (< 85km) [#69](https://github.com/egavazzi/AURORA.jl/pull/69)
+- Increase possible maximum energy [#67](https://github.com/egavazzi/AURORA.jl/pull/67)
+- Improve performances, making simulations around 3x faster to run [#64](https://github.com/egavazzi/AURORA.jl/pull/64)
+- Speed-up scattering calculations, can change results very slightly [#66](https://github.com/egavazzi/AURORA.jl/pull/66)
 
 ## v0.5.0 - 2025-05-01
 - Faster phase functions calculations [#62](https://github.com/egavazzi/AURORA.jl/pull/62)

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -196,9 +196,13 @@ function load_neutral_densities(msis_file, h_atm)
 	nO2[end-5:end-3] .= erf_factor .* nO2[end-5:end-3]
 
     # Ensure no negative densities
-    nO[nO .< 0] .= 0
-    nN2[nN2 .< 0] .= 0
-    nO2[nO2 .< 0] .= 0
+    if any(nO .< 0) || any(nN2 .< 0) || any(nO2 .< 0)
+        @warn "Negative densities found. They were set to 0, but you might want to check " *
+              "why that happened"
+        nO[nO .< 0] .= 0
+        nN2[nN2 .< 0] .= 0
+        nO2[nO2 .< 0] .= 0
+    end
 
     n_neutrals = (nN2 = nN2, nO2 = nO2, nO = nO)
     return n_neutrals, Tn

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -172,19 +172,21 @@ function load_neutral_densities(msis_file, h_atm)
     z_msis = data_msis[:, 1] # extract the z-grid of the msis data
     data_msis = data_msis[:, [1:5; end]] # keep only data of interest (and also avoid NaN values)
 
-    # create the interpolator
-    msis_interpolator = [PCHIPInterpolation(data_msis[:, i], z_msis;
-                                            extrapolation = ExtrapolationType.Extension)
+    # Create the interpolator
+    # The interpolation is done in log space, with the benefit that the linear extrapolation
+    # is actually an exponential one when we move back to linear space
+    msis_interpolator = [PCHIPInterpolation(log10.(data_msis[:, i]), z_msis;
+                                            extrapolation = ExtrapolationType.Linear)
                          for i in axes(data_msis, 2)]
-    # interpolate the msis data over our h_atm grid
-    msis_interpolated = [msis_interpolator[i](h_atm / 1e3) for i in axes(data_msis, 2)]
+    msis_interpolated = [exp.(msis_interpolator[i](h_atm / 1e3)) for i in axes(data_msis, 2)]
 
-    # extract the neutral densities
+    # Extract the neutral densities
     nN2 = msis_interpolated[3] # already in m⁻³
     nO2 = msis_interpolated[4] # already in m⁻³
     nO = msis_interpolated[5]  # already in m⁻³
     Tn = msis_interpolated[6]
 
+    # Boundary conditions
     nO[end-2:end] .= 0
 	nN2[end-2:end] .= 0
 	nO2[end-2:end] .= 0
@@ -192,6 +194,11 @@ function load_neutral_densities(msis_file, h_atm)
 	nO[end-5:end-3] .= erf_factor .* nO[end-5:end-3]
 	nN2[end-5:end-3] .= erf_factor .* nN2[end-5:end-3]
 	nO2[end-5:end-3] .= erf_factor .* nO2[end-5:end-3]
+
+    # Ensure no negative densities
+    nO[nO .< 0] .= 0
+    nN2[nN2 .< 0] .= 0
+    nO2[nO2 .< 0] .= 0
 
     n_neutrals = (nN2 = nN2, nO2 = nO2, nO = nO)
     return n_neutrals, Tn
@@ -216,23 +223,25 @@ Load the electron density and temperature.
 - `Te`: e- temperature (K). Vector [nZ]
 """
 function load_electron_densities(iri_file, h_atm)
-    # read the file and extract z-grid of the iri data
+    # Read the file and extract z-grid of the iri data
     data_iri = readdlm(iri_file, skipstart=14)
     data_iri[isnan.(data_iri)] .= 0
 
     z_iri = data_iri[:, 1]
 
-    # create the interpolator
-    iri_interpolator = [PCHIPInterpolation(data_iri[:, i], z_iri;
-                                           extrapolation = ExtrapolationType.Extension)
+    # Create the interpolator
+    # The interpolation is done in log space, with the benefit that the linear extrapolation
+    # is actually an exponential one when we move back to linear space
+    iri_interpolator = [PCHIPInterpolation(log10.(data_iri[:, i]), z_iri;
+                                           extrapolation = ExtrapolationType.Linear)
                         for i in axes(data_iri, 2)]
-    # interpolate the iri data over our h_atm grid
-    iri_interpolated = [iri_interpolator[i](h_atm / 1e3) for i in axes(data_iri, 2)]
+    iri_interpolated = [exp.(iri_interpolator[i](h_atm / 1e3)) for i in axes(data_iri, 2)]
 
-    # extract electron density and temperature
+    # Extract electron density and temperature
     ne = iri_interpolated[2] # from cm⁻³ to m⁻³
     Te = iri_interpolated[5]
 
+    # Ensure no negative densities, and a default Te value of 350
     ne[ne .< 0] .= 1
     Te[Te .== -1] .= 350
 

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -175,7 +175,7 @@ function load_neutral_densities(msis_file, h_atm)
     # Create the interpolator
     # The interpolation is done in log space, with the benefit that the linear extrapolation
     # is actually an exponential one when we move back to linear space
-    msis_interpolator = [PCHIPInterpolation(log10.(data_msis[:, i]), z_msis;
+    msis_interpolator = [PCHIPInterpolation(log.(data_msis[:, i]), z_msis;
                                             extrapolation = ExtrapolationType.Linear)
                          for i in axes(data_msis, 2)]
     msis_interpolated = [exp.(msis_interpolator[i](h_atm / 1e3)) for i in axes(data_msis, 2)]
@@ -232,7 +232,7 @@ function load_electron_densities(iri_file, h_atm)
     # Create the interpolator
     # The interpolation is done in log space, with the benefit that the linear extrapolation
     # is actually an exponential one when we move back to linear space
-    iri_interpolator = [PCHIPInterpolation(log10.(data_iri[:, i]), z_iri;
+    iri_interpolator = [PCHIPInterpolation(log.(data_iri[:, i]), z_iri;
                                            extrapolation = ExtrapolationType.Linear)
                         for i in axes(data_iri, 2)]
     iri_interpolated = [exp.(iri_interpolator[i](h_atm / 1e3)) for i in axes(data_iri, 2)]

--- a/src/setup.jl
+++ b/src/setup.jl
@@ -234,12 +234,12 @@ function load_electron_densities(iri_file, h_atm)
     # is actually an exponential one when we move back to linear space
     iri_interpolator = [PCHIPInterpolation(log.(data_iri[:, i]), z_iri;
                                            extrapolation = ExtrapolationType.Linear)
-                        for i in axes(data_iri, 2)]
-    iri_interpolated = [exp.(iri_interpolator[i](h_atm / 1e3)) for i in axes(data_iri, 2)]
+                        for i in [2, 5]]
+    iri_interpolated = [exp.(iri_interpolator[i](h_atm / 1e3)) for i in eachindex(iri_interpolator)]
 
     # Extract electron density and temperature
-    ne = iri_interpolated[2] # from cm⁻³ to m⁻³
-    Te = iri_interpolated[5]
+    ne = iri_interpolated[1] # already in m⁻³
+    Te = iri_interpolated[2]
 
     # Ensure no negative densities, and a default Te value of 350
     ne[ne .< 0] .= 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using AURORA
 
 include("test_results.jl")
 include("test_scattering.jl")
+include("test_setup.jl")

--- a/test/test_setup.jl
+++ b/test/test_setup.jl
@@ -1,0 +1,31 @@
+@testset "Neutral densities" begin
+    h_atm = make_altitude_grid(50, 800)
+    msis_file = find_nrlmsis_file()
+
+    @test_nowarn n_neutrals, Tn = AURORA.load_neutral_densities(msis_file, h_atm)
+
+    n_neutrals, Tn = AURORA.load_neutral_densities(msis_file, h_atm)
+    for i in eachindex(n_neutrals)
+        @test !any(isnan.(n_neutrals[i]))
+        @test !any(isinf.(n_neutrals[i]))
+        @test !any(n_neutrals[i] .< 0)
+    end
+
+    @test !any(isnan.(Tn))
+    @test !any(isinf.(Tn))
+    @test !any(Tn .< 0)
+end
+
+@testset "Electron densities" begin
+    h_atm = make_altitude_grid(50, 800)
+    iri_file = find_iri_file()
+    ne, Te = AURORA.load_electron_densities(iri_file, h_atm)
+
+    @test !any(isnan.(ne))
+    @test !any(isinf.(ne))
+    @test !any(ne .< 0)
+
+    @test !any(isnan.(Te))
+    @test !any(isinf.(Te))
+    @test !any(Te .< 0)
+end


### PR DESCRIPTION
If very low altitudes are used (e.g. 70km), they can be lower than the bottom of the msis profile and some extrapolation will be used. However, in the current version of the code, the extrapolation can produce negative values which results in negative densities (not very physical).

This PR make the the interpolation/extrapolation in log space instead of linear. If for some reason there are still some negative densities, they are set to 0 and a warning is thrown.

## Problem
Current version of the code. Very negative densities in O (green line) at ~80km altitude.
<img width="600" height="482" alt="old_densities" src="https://github.com/user-attachments/assets/03fe4202-c010-419d-9eb6-a505d32737ed" />

## This PR
<img width="600" height="482" alt="new_densities" src="https://github.com/user-attachments/assets/fadc2c52-0a81-4dbf-bd33-dcc10dbf1a95" />



## TODO
- [x] add an entry in CHANGELOG.md
- [x] add tests
