### PR TITLE
add error message for invalid iri data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Add error message if iri calculations return invalid data or if loading invalid data from file [#116](https://github.com/egavazzi/AURORA.jl/pull/116)
+- Add error message for when iri calculations return invalid data or when loading invalid data from file [#116](https://github.com/egavazzi/AURORA.jl/pull/116)
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Add error message if iri calculations return invalid data or if loading invalid data from file [#116](https://github.com/egavazzi/AURORA.jl/pull/116)
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/src/ionosphere/iri/calculation.jl
+++ b/src/ionosphere/iri/calculation.jl
@@ -60,6 +60,17 @@ function calculate_iri_data(; year = 2018, month = 12, day = 7, hour = 11, minut
     iri_data = iri_data[:, :, 1]'
     # add a column with the altitude
     iri_data = hcat(Vector(height), iri_data)
+
+    # Validate: check that IRI didn't return all -1 sentinel values
+    # (this happens when iri2016's solar index data files don't cover the requested date)
+    if all(iri_data[:, 2:5] .== -1)  # ne, Tn, Ti, Te
+        error("IRI-2016 returned all -1 sentinel values for $(year)-$(lpad(month,2,'0'))-" *
+              "$(lpad(day,2,'0')) $(lpad(hour,2,'0')):$(lpad(minute,2,'0')) UT at " *
+              "($(lat)°N, $(lon)°E).\n" *
+              "This can mean the iri2016 package's solar index data files " *
+              "(apf107.dat, ig_rz.dat) do not cover the requested date.\n")
+    end
+
     # add a header with the name of columns
     iri_data = vcat(["height(km)" "ne(m-3)" "Tn(K)" "Ti(K)" "Te(K)" "nO+(m-3)" "nH+(m-3)" "nHe+(m-3)" "nO2+(m-3)" "nNO+(m-3)" "nCI(m-3)" "nN+(m-3)" "NmF2" "hmF2" "NmF1" "hmF1" "NmE" "hmE" "TEC" "EqVertIonDrift" "foF2"], iri_data)
     parameters = (; year, month, day, hour, minute, lat, lon, height)

--- a/src/ionosphere/iri/io.jl
+++ b/src/ionosphere/iri/io.jl
@@ -197,6 +197,13 @@ function load_iri_data(iri_file)
                 EqVertIonDrift = data_matrix[:, 20],  # Equatorial vertical ion drift
                 foF2 = data_matrix[:, 21])
 
+    # Validate: check that the loaded data doesn't contain only -1 sentinel values
+    if all(iri_data.ne .== -1) && all(iri_data.Te .== -1)
+        error("The IRI file at\n  $(iri_file)\n" *
+              "contains only -1 sentinel values (no valid ionospheric profiles).\n" *
+              "You might want to use another file or regenerate it.")
+    end
+
     return iri_data
 end
 


### PR DESCRIPTION
The python iri2016 wrapper produces invalid data after a certain date due to outdated coefficient files. Not sure exactly after what specific year/date the problem occurs, but it is at least from/after November 2022.

Need to find a way to properly circumvent/solve that issue, but in the meantime this PR adds an error message in case iri2016 returns only invalid (-1) values when called to calculate the profiles. Or similarly if the data loaded from a cached iri file only contains -1 values. This is better than the current version which throws errors about the interpolation failing.

## TODO
- [x] add an entry in CHANGELOG.md
