### PR TITLE
Add solver types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125)
+- **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125) [#126](https://github.com/egavazzi/AURORA.jl/pull/126)
   - Simulations are now set up by building an `AuroraModel`, creating an `InputFlux`, constructing an `AuroraSimulation`, and calling `run!(sim)`. The old `calculate_e_transport()` and `calculate_e_transport_steady_state()` are removed.
   - Possibility to visualize the model, the input, etc.
   - Visit the (recently updated and expanded) [documentation](https://egavazzi.github.io/AURORA.jl/dev/) for more details and examples.

--- a/docs/src/10-tutorials/20-time-dependent.md
+++ b/docs/src/10-tutorials/20-time-dependent.md
@@ -87,10 +87,10 @@ sim = AuroraSimulation(
     flux,
     savedir;
     mode=TimeDependentMode(
-        0.5,                # total simulation time [s]
-        0.01;               # output time step [s] (save every 10 ms)
-        CFL_number=256,     # CFL stability parameter (higher → coarser internal stepping)
-        max_memory_gb=4.0   # memory budget [GB] — controls loop partitioning
+        duration=0.5,           # total simulation time [s]
+        dt=0.01,                # output time step [s] (save every 10 ms)
+        CFL_number=256,         # CFL stability parameter (higher → coarser internal stepping)
+        max_memory_gb=4.0       # memory budget [GB] — controls loop partitioning
     )
 )
 ```

--- a/docs/src/10-tutorials/20-time-dependent.md
+++ b/docs/src/10-tutorials/20-time-dependent.md
@@ -76,7 +76,8 @@ See the [Input flux](@ref "Input Flux") tutorial for other spectrum types, modul
 ## Step 3: Create and run the simulation
 
 Bundle the model and input flux into an [`AuroraSimulation`](@ref). For a time-dependent
-simulation you specify the total duration and the output cadence:
+simulation, pass a [`TimeDependentSolver`](@ref) specifying the total duration and output
+cadence:
 
 ```@example time_dep
 savedir = mkpath(joinpath("data", "my_first_simulation"))
@@ -84,18 +85,20 @@ savedir = mkpath(joinpath("data", "my_first_simulation"))
 sim = AuroraSimulation(
     model,
     flux,
-    0.5,                # total simulation time [s]
-    0.01,               # output time step [s] (save every 10 ms)
     savedir;
-    CFL_number=256,     # CFL stability parameter (higher → coarser internal stepping)
-    max_memory_gb=4.0   # memory budget [GB] — controls loop partitioning
+    solver=TimeDependentSolver(
+        0.5,                # total simulation time [s]
+        0.01;               # output time step [s] (save every 10 ms)
+        CFL_number=256,     # CFL stability parameter (higher → coarser internal stepping)
+        max_memory_gb=4.0   # memory budget [GB] — controls loop partitioning
+    )
 )
 ```
 
 ### Understanding the time grid
 
-The `ResolvedTimeGrid` is constructed automatically inside `AuroraSimulation`. It
-determines two key quantities:
+The [`RefinedTimeGrid`](@ref) is constructed automatically from the
+[`TimeDependentSolver`](@ref) parameters. It determines two key quantities:
 
 - **`dt_resolved`**: the internal time step, chosen to satisfy the CFL condition. This is
   typically much smaller than the requested output `dt`.

--- a/docs/src/10-tutorials/20-time-dependent.md
+++ b/docs/src/10-tutorials/20-time-dependent.md
@@ -76,7 +76,7 @@ See the [Input flux](@ref "Input Flux") tutorial for other spectrum types, modul
 ## Step 3: Create and run the simulation
 
 Bundle the model and input flux into an [`AuroraSimulation`](@ref). For a time-dependent
-simulation, pass a [`TimeDependentSolver`](@ref) specifying the total duration and output
+simulation, pass a [`TimeDependentMode`](@ref) specifying the total duration and output
 cadence:
 
 ```@example time_dep
@@ -86,7 +86,7 @@ sim = AuroraSimulation(
     model,
     flux,
     savedir;
-    solver=TimeDependentSolver(
+    mode=TimeDependentMode(
         0.5,                # total simulation time [s]
         0.01;               # output time step [s] (save every 10 ms)
         CFL_number=256,     # CFL stability parameter (higher → coarser internal stepping)
@@ -98,7 +98,7 @@ sim = AuroraSimulation(
 ### Understanding the time grid
 
 The [`RefinedTimeGrid`](@ref) is constructed automatically from the
-[`TimeDependentSolver`](@ref) parameters. It determines two key quantities:
+[`TimeDependentMode`](@ref) parameters. It determines two key quantities:
 
 - **`dt_resolved`**: the internal time step, chosen to satisfy the CFL condition. This is
   typically much smaller than the requested output `dt`.

--- a/docs/src/30-developer/10-architecture.md
+++ b/docs/src/30-developer/10-architecture.md
@@ -168,7 +168,7 @@ The dispatch between steady-state and time-dependent is controlled by the
 
 - **Steady-state** ([`SteadyStateMode`](@ref)): No time stepping. The solver finds the
   equilibrium flux for each energy level by inverting a sparse linear system
-  (``M \cdot I_e = Q``). With time parameters (`SteadyStateMode(duration, dt)`), each
+  (``M \cdot I_e = Q``). With time parameters (`SteadyStateMode(duration=..., dt=...)`), each
   time point is solved independently (multi-step steady-state).
 
 - **Time-dependent** ([`TimeDependentMode`](@ref)): The Crank-Nicolson scheme advances

--- a/docs/src/30-developer/10-architecture.md
+++ b/docs/src/30-developer/10-architecture.md
@@ -62,7 +62,7 @@ src/
 │   └── scattering.jl            # Pitch-angle scattering matrices
 │
 ├── solvers/
-│   ├── types.jl                 # AbstractSolver, SteadyStateSolver, TimeDependentSolver
+│   ├── types.jl                 # AbstractMode, SteadyStateMode, TimeDependentMode
 │   ├── transport_matrices.jl    # TransportMatrices struct
 │   ├── matrix_building.jl       # update_A!, update_B! (collision operators)
 │   ├── crank_nicolson.jl        # Standard Crank-Nicolson scheme
@@ -71,7 +71,7 @@ src/
 │   └── steady_state_optimized.jl    # In-place optimized version
 │
 ├── simulation/
-│   ├── types.jl                 # AuroraSimulation, AbstractTimeGrid, RefinedTimeGrid, UniformTimeGrid
+│   ├── types.jl                 # AuroraSimulation, AbstractTimeConfig, RefinedTimeGrid, UniformTimeGrid
 │   ├── cache.jl                 # SimulationCache, SolverCache, DegradationCache
 │   ├── initialize.jl            # initialize! — allocates cache
 │   └── run.jl                   # run!, solve!, energy_loop!, solve_energy_step!
@@ -93,8 +93,8 @@ src/
 |------|------|
 | [`AuroraModel`](@ref) | Physical model: grids + atmosphere + cross sections |
 | [`InputFlux`](@ref) | Precipitating electron specification: spectrum × modulation |
-| [`AuroraSimulation`](@ref) | Complete simulation descriptor: model + flux + solver + output |
-| [`AbstractSolver`](@ref) | Solver strategy: [`SteadyStateSolver`](@ref) or [`TimeDependentSolver`](@ref) |
+| [`AuroraSimulation`](@ref) | Complete simulation descriptor: model + flux + mode + output |
+| [`AbstractMode`](@ref) | Solver strategy: [`SteadyStateMode`](@ref) or [`TimeDependentMode`](@ref) |
 | `SimulationCache` | Internal workspace: solver matrices, flux arrays, factorizations |
 | `TransportMatrices` | Matrices A (loss), B (scattering), D (diffusion), Q (source) |
 | [`RefinedTimeGrid`](@ref) | Time discretization with CFL refinement and loop partitioning |
@@ -118,17 +118,17 @@ run!(sim::AuroraSimulation)
 │
 └── solve!(sim)
     │
-    ├─── [steady-state: SteadyStateSolver, single-step]
+    ├─── [steady-state: SteadyStateMode, single-step]
     │    └── energy_loop!(sim, Ie_top, 1, 1)
     │
-    ├─── [steady-state: SteadyStateSolver, multi-step]
+    ├─── [steady-state: SteadyStateMode, multi-step]
     │    └── for i_step in 1:n_steps
     │        ├── Reset solver state
     │        ├── Compute Ie_top for this time point
     │        ├── energy_loop!(sim, Ie_top_step, 1, 1)
     │        └── Accumulate results
     │
-    └─── [time-dependent: TimeDependentSolver]
+    └─── [time-dependent: TimeDependentMode]
          └── for i_loop in 1:n_loop
              ├── Extract Ie_top chunk for this time window
              ├── energy_loop!(sim, Ie_top_chunk, i_loop, n_loop)
@@ -164,14 +164,14 @@ when the solver reaches the lower energy levels. This is what we refer to as the
 ## Steady-state vs. time-dependent
 
 The dispatch between steady-state and time-dependent is controlled by the
-[`AbstractSolver`](@ref) type stored in `sim.solver`:
+[`AbstractMode`](@ref) type stored in `sim.mode`:
 
-- **Steady-state** ([`SteadyStateSolver`](@ref)): No time stepping. The solver finds the
+- **Steady-state** ([`SteadyStateMode`](@ref)): No time stepping. The solver finds the
   equilibrium flux for each energy level by inverting a sparse linear system
-  (``M \cdot I_e = Q``). With time parameters (`SteadyStateSolver(t_total, dt)`), each
+  (``M \cdot I_e = Q``). With time parameters (`SteadyStateMode(duration, dt)`), each
   time point is solved independently (multi-step steady-state).
 
-- **Time-dependent** ([`TimeDependentSolver`](@ref)): The Crank-Nicolson scheme advances
+- **Time-dependent** ([`TimeDependentMode`](@ref)): The Crank-Nicolson scheme advances
   the solution in time at each energy level. The simulation may be split into multiple
   *loops* (time chunks) to fit within a memory budget, controlled by `max_memory_gb`.
 

--- a/docs/src/30-developer/10-architecture.md
+++ b/docs/src/30-developer/10-architecture.md
@@ -62,6 +62,7 @@ src/
 │   └── scattering.jl            # Pitch-angle scattering matrices
 │
 ├── solvers/
+│   ├── types.jl                 # AbstractSolver, SteadyStateSolver, TimeDependentSolver
 │   ├── transport_matrices.jl    # TransportMatrices struct
 │   ├── matrix_building.jl       # update_A!, update_B! (collision operators)
 │   ├── crank_nicolson.jl        # Standard Crank-Nicolson scheme
@@ -70,7 +71,7 @@ src/
 │   └── steady_state_optimized.jl    # In-place optimized version
 │
 ├── simulation/
-│   ├── types.jl                 # AuroraSimulation, ResolvedTimeGrid
+│   ├── types.jl                 # AuroraSimulation, AbstractTimeGrid, RefinedTimeGrid, UniformTimeGrid
 │   ├── cache.jl                 # SimulationCache, SolverCache, DegradationCache
 │   ├── initialize.jl            # initialize! — allocates cache
 │   └── run.jl                   # run!, solve!, energy_loop!, solve_energy_step!
@@ -92,10 +93,12 @@ src/
 |------|------|
 | [`AuroraModel`](@ref) | Physical model: grids + atmosphere + cross sections |
 | [`InputFlux`](@ref) | Precipitating electron specification: spectrum × modulation |
-| [`AuroraSimulation`](@ref) | Complete simulation descriptor: model + flux + timing + output |
+| [`AuroraSimulation`](@ref) | Complete simulation descriptor: model + flux + solver + output |
+| [`AbstractSolver`](@ref) | Solver strategy: [`SteadyStateSolver`](@ref) or [`TimeDependentSolver`](@ref) |
 | `SimulationCache` | Internal workspace: solver matrices, flux arrays, factorizations |
 | `TransportMatrices` | Matrices A (loss), B (scattering), D (diffusion), Q (source) |
-| `ResolvedTimeGrid` | Time discretization with CFL refinement and loop partitioning |
+| [`RefinedTimeGrid`](@ref) | Time discretization with CFL refinement and loop partitioning |
+| [`UniformTimeGrid`](@ref) | Simple uniform grid for multi-step steady-state simulations |
 
 ## Execution flow
 
@@ -115,10 +118,17 @@ run!(sim::AuroraSimulation)
 │
 └── solve!(sim)
     │
-    ├─── [steady-state path: sim.time === nothing]
+    ├─── [steady-state: SteadyStateSolver, single-step]
     │    └── energy_loop!(sim, Ie_top, 1, 1)
     │
-    └─── [time-dependent path: sim.time !== nothing]
+    ├─── [steady-state: SteadyStateSolver, multi-step]
+    │    └── for i_step in 1:n_steps
+    │        ├── Reset solver state
+    │        ├── Compute Ie_top for this time point
+    │        ├── energy_loop!(sim, Ie_top_step, 1, 1)
+    │        └── Accumulate results
+    │
+    └─── [time-dependent: TimeDependentSolver]
          └── for i_loop in 1:n_loop
              ├── Extract Ie_top chunk for this time window
              ├── energy_loop!(sim, Ie_top_chunk, i_loop, n_loop)
@@ -153,16 +163,17 @@ when the solver reaches the lower energy levels. This is what we refer to as the
 
 ## Steady-state vs. time-dependent
 
-The dispatch between steady-state and time-dependent is determined by the `time` field of
-[`AuroraSimulation`](@ref):
+The dispatch between steady-state and time-dependent is controlled by the
+[`AbstractSolver`](@ref) type stored in `sim.solver`:
 
-- **Steady-state** (`sim.time === nothing`): No time stepping. The solver finds the
+- **Steady-state** ([`SteadyStateSolver`](@ref)): No time stepping. The solver finds the
   equilibrium flux for each energy level by inverting a sparse linear system
-  (``M \cdot I_e = Q``).
+  (``M \cdot I_e = Q``). With time parameters (`SteadyStateSolver(t_total, dt)`), each
+  time point is solved independently (multi-step steady-state).
 
-- **Time-dependent** (`sim.time !== nothing`): The Crank-Nicolson scheme advances the
-  solution in time at each energy level. The simulation may be split into multiple *loops*
-  (time chunks) to fit within a memory budget, controlled by `max_memory_gb`.
+- **Time-dependent** ([`TimeDependentSolver`](@ref)): The Crank-Nicolson scheme advances
+  the solution in time at each energy level. The simulation may be split into multiple
+  *loops* (time chunks) to fit within a memory budget, controlled by `max_memory_gb`.
 
 For more details on the transport equation, matrix construction, and solver internals, see
 [Solver Internals](@ref "Internals").

--- a/docs/src/40-api/model.md
+++ b/docs/src/40-api/model.md
@@ -14,6 +14,14 @@ AuroraModel
 AuroraSimulation
 ```
 
+## Solver types
+
+```@docs; canonical=false
+AbstractSolver
+SteadyStateSolver
+TimeDependentSolver
+```
+
 ## Simulation lifecycle
 
 ```@docs; canonical=false

--- a/docs/src/40-api/model.md
+++ b/docs/src/40-api/model.md
@@ -14,12 +14,12 @@ AuroraModel
 AuroraSimulation
 ```
 
-## Solver types
+## Mode/Solver types
 
 ```@docs; canonical=false
-AbstractSolver
-SteadyStateSolver
-TimeDependentSolver
+AbstractMode
+SteadyStateMode
+TimeDependentMode
 ```
 
 ## Simulation lifecycle

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ flux = InputFlux(
 # Create and run a short time-dependent simulation
 savedir = mkpath(joinpath("data", "my_first_simulation"))
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(0.2, 0.01; CFL_number=128))
+                       mode=TimeDependentMode(duration=0.2, dt=0.01, CFL_number=128))
 run!(sim)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,7 +30,7 @@ flux = InputFlux(
 # Create and run a short time-dependent simulation
 savedir = mkpath(joinpath("data", "my_first_simulation"))
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(0.2, 0.01; CFL_number=128))
+                       mode=TimeDependentMode(0.2, 0.01; CFL_number=128))
 run!(sim)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,8 @@ flux = InputFlux(
 
 # Create and run a short time-dependent simulation
 savedir = mkpath(joinpath("data", "my_first_simulation"))
-sim = AuroraSimulation(model, flux, 0.2, 0.01, savedir; CFL_number=128)
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(0.2, 0.01; CFL_number=128))
 run!(sim)
 ```
 

--- a/ext/src/plot_input.jl
+++ b/ext/src/plot_input.jl
@@ -29,11 +29,11 @@ function AURORA.plot_input(sim::AURORA.AuroraSimulation)
     flux = sim.flux
 
     if isnothing(sim.time)
-        # Steady-state: compute flux [n_beams, 1, n_E]
+        # Single-step steady-state: no time grid
         Ie_top = AURORA.compute_flux(flux, model)
         return _plot_input_steady_state(Ie_top, E_centers, ΔE, θ_lims, Ω_beam, flux)
     else
-        # Time-dependent: compute flux [n_beams, n_t, n_E]
+        # Time-dependent or multi-step steady-state: has a time grid
         Ie_top = AURORA.compute_flux(flux, model, sim.time.t)
         t = collect(sim.time.t)
         return _plot_input_time_dependent(Ie_top, t, E_centers, ΔE, θ_lims, Ω_beam, flux)

--- a/ext/src/plot_input.jl
+++ b/ext/src/plot_input.jl
@@ -28,7 +28,7 @@ function AURORA.plot_input(sim::AURORA.AuroraSimulation)
     Ω_beam = model.scattering.Ω_beam
     flux = sim.flux
 
-    if isnothing(sim.time)
+    if sim.time isa AURORA.SingleStepConfig
         # Single-step steady-state: no time grid
         Ie_top = AURORA.compute_flux(flux, model)
         return _plot_input_steady_state(Ie_top, E_centers, ΔE, θ_lims, Ω_beam, flux)

--- a/scripts/Control_script.jl
+++ b/scripts/Control_script.jl
@@ -8,11 +8,6 @@ B_angle_to_zenith = 13;         # (°) angle between the B-field line and the ze
 
 t_total = 0.5;                  # (s) total simulation time
 dt = 0.001;                     # (s) time step for saving data
-
-# Options to control how the simulation is split into time chunks to manage memory:
-# n_loop = 10;                  # (optional) define manually the number of loops to run
-# max_memory_gb = 8.0           # (optional) determine n_loop based on limit memory usage
-
 CFL_number = 128;
 
 msis_file = find_msis_file(
@@ -36,10 +31,14 @@ savedir = make_savedir(root_savedir, name_savedir)
 flux = InputFlux(FlatSpectrum(1e-2; E_min=100), SinusoidalFlickering(5.0);
                  beams=1, z_source=3000.0)
 
-## Create the simulation
-sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number)
+## Create and run the simulation
+solver = TimeDependentSolver(t_total, dt;
+                             CFL_number,
+                             # n_loop = 10,             # (optional) define manually the number of loops to run
+                             # max_memory_gb = 8.0,     # (optional) or determine n_loop based on limit memory usage
+                             )
 
-## Run the simulation
+sim = AuroraSimulation(model, flux, savedir; solver)
 run!(sim)
 
 ## Run the analysis

--- a/scripts/Control_script.jl
+++ b/scripts/Control_script.jl
@@ -6,10 +6,6 @@ altitude_lims = [100, 600];     # (km) altitude limits of the ionosphere
 E_max = 1000;                   # (eV) upper limit to the energy grid
 B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-duration = 0.5;                  # (s) total simulation time
-dt = 0.001;                     # (s) time step for saving data
-CFL_number = 128;
-
 msis_file = find_msis_file(
     year=2005, month=10, day=8, hour=22, minute=0, lat=70, lon=19, height=85:1:700
     );
@@ -32,8 +28,9 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=100), SinusoidalFlickering(5.0);
                  beams=1, z_source=3000.0)
 
 ## Create and run the simulation
-mode = TimeDependent(duration, dt;
-                     CFL_number,
+mode = TimeDependent(duration = 0.5,            # (s) total simulation time
+                     dt = 0.001,                # (s) time step for saving data
+                     CFL_number = 128,
                      # n_loop = 10,             # (optional) define manually the number of loops to run
                      # max_memory_gb = 8.0,     # (optional) or determine n_loop based on limit memory usage
                      )

--- a/scripts/Control_script.jl
+++ b/scripts/Control_script.jl
@@ -6,7 +6,7 @@ altitude_lims = [100, 600];     # (km) altitude limits of the ionosphere
 E_max = 1000;                   # (eV) upper limit to the energy grid
 B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-t_total = 0.5;                  # (s) total simulation time
+duration = 0.5;                  # (s) total simulation time
 dt = 0.001;                     # (s) time step for saving data
 CFL_number = 128;
 
@@ -32,13 +32,13 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=100), SinusoidalFlickering(5.0);
                  beams=1, z_source=3000.0)
 
 ## Create and run the simulation
-solver = TimeDependentSolver(t_total, dt;
-                             CFL_number,
-                             # n_loop = 10,             # (optional) define manually the number of loops to run
-                             # max_memory_gb = 8.0,     # (optional) or determine n_loop based on limit memory usage
-                             )
+mode = TimeDependent(duration, dt;
+                     CFL_number,
+                     # n_loop = 10,             # (optional) define manually the number of loops to run
+                     # max_memory_gb = 8.0,     # (optional) or determine n_loop based on limit memory usage
+                     )
 
-sim = AuroraSimulation(model, flux, savedir; solver)
+sim = AuroraSimulation(model, flux, savedir; mode)
 run!(sim)
 
 ## Run the analysis

--- a/scripts/Control_script_SteadyState.jl
+++ b/scripts/Control_script_SteadyState.jl
@@ -22,7 +22,7 @@ name_savedir = ""   # name of the experiment folder
 savedir = make_savedir(root_savedir, name_savedir)
 
 ## Define input flux
-flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 1000); beams=1:2)
+flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
 ## Create and run the simulation
 ## Create and run the simulation

--- a/scripts/Control_script_SteadyState.jl
+++ b/scripts/Control_script_SteadyState.jl
@@ -22,12 +22,16 @@ name_savedir = ""   # name of the experiment folder
 savedir = make_savedir(root_savedir, name_savedir)
 
 ## Define input flux
-flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
+flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 1000); beams=1:2)
 
 ## Create and run the simulation
+## Create and run the simulation
 # Single-step steady-state:
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyState())
 run!(sim)
+# Multi-step steady-state (each step solved independently):
+# sim = AuroraSimulation(model, flux, savedir; mode=SteadyState(0.5, 0.05))
+# run!(sim)
 
 ## Analyze the results
 make_Ie_top_file(sim)

--- a/scripts/Control_script_SteadyState.jl
+++ b/scripts/Control_script_SteadyState.jl
@@ -30,7 +30,7 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 1000); beams=1:2)
 sim = AuroraSimulation(model, flux, savedir; mode=SteadyState())
 run!(sim)
 # Multi-step steady-state (each step solved independently):
-# sim = AuroraSimulation(model, flux, savedir; mode=SteadyState(0.5, 0.05))
+# sim = AuroraSimulation(model, flux, savedir; mode=SteadyState(duration=0.5, dt=0.05))
 # run!(sim)
 
 ## Analyze the results

--- a/scripts/Control_script_SteadyState.jl
+++ b/scripts/Control_script_SteadyState.jl
@@ -25,11 +25,12 @@ savedir = make_savedir(root_savedir, name_savedir)
 flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
 ## Create and run the simulation
-sim = AuroraSimulation(model, flux, savedir)
+# Single-step steady-state:
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
 run!(sim)
 
 ## Analyze the results
 make_Ie_top_file(sim)
 make_volume_excitation_file(sim)
 make_current_file(sim)
-# make_column_excitation_file(sim) -- does not make sense for steady-state
+make_column_excitation_file(sim)

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -37,6 +37,9 @@ export InputFlux, evaluate_spectrum, apply_modulation, compute_flux
 export Ie_top_from_file
 
 
+include("solvers/types.jl")
+export AbstractSolver, SteadyStateSolver, TimeDependentSolver
+
 include("solvers/transport_matrices.jl")
 include("solvers/matrix_building.jl")
 
@@ -50,7 +53,7 @@ include("solvers/steady_state_optimized.jl")
 
 include("simulation/cache.jl")
 include("simulation/types.jl")
-export AuroraSimulation, ResolvedTimeGrid
+export AuroraSimulation, RefinedTimeGrid, UniformTimeGrid, AbstractTimeGrid
 include("simulation/initialize.jl")
 export initialize!
 include("simulation/run.jl")
@@ -84,7 +87,8 @@ Requires a Makie backend (e.g. `using CairoMakie` or `using GLMakie`).
 # Examples
 ```julia
 using CairoMakie
-sim = AuroraSimulation(model, flux, 0.5, 0.001, savedir)
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
 fig = plot_input(sim)
 ```
 """

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -89,7 +89,7 @@ Requires a Makie backend (e.g. `using CairoMakie` or `using GLMakie`).
 ```julia
 using CairoMakie
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(0.5, 0.001))
+                       mode=TimeDependentMode(duration=0.5, dt=0.001))
 fig = plot_input(sim)
 ```
 """

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -38,7 +38,7 @@ export Ie_top_from_file
 
 
 include("solvers/types.jl")
-export AbstractSolver, SteadyStateSolver, TimeDependentSolver
+export AbstractMode, SteadyStateMode, TimeDependentMode, SteadyState, TimeDependent
 
 include("solvers/transport_matrices.jl")
 include("solvers/matrix_building.jl")
@@ -53,7 +53,8 @@ include("solvers/steady_state_optimized.jl")
 
 include("simulation/cache.jl")
 include("simulation/types.jl")
-export AuroraSimulation, RefinedTimeGrid, UniformTimeGrid, AbstractTimeGrid
+export AuroraSimulation
+export AbstractTimeConfig, SingleStepConfig, UniformTimeGrid, RefinedTimeGrid
 include("simulation/initialize.jl")
 export initialize!
 include("simulation/run.jl")
@@ -88,7 +89,7 @@ Requires a Makie backend (e.g. `using CairoMakie` or `using GLMakie`).
 ```julia
 using CairoMakie
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(0.5, 0.001))
 fig = plot_input(sim)
 ```
 """

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -56,46 +56,35 @@ function build_simulation_cache(sim::AuroraSimulation)
 end
 
 # Time parameters for working arrays: (n_t, t_loop)
-_cache_time_params(sim::AuroraSimulation) = _cache_time_params(sim, sim.solver)
+_cache_time_params(sim::AuroraSimulation) = _cache_time_params(sim.time)
 
-function _cache_time_params(sim::AuroraSimulation, ::SteadyStateSolver)
-    # Both single-step and multi-step SS solve one time slice at a time
+function _cache_time_params(::SingleStepConfig)
+    # Single-step steady-state solves one time slice
     return 1, (1:1:1)
 end
-function _cache_time_params(sim::AuroraSimulation, ::TimeDependentSolver)
-    time = sim.time::RefinedTimeGrid
+function _cache_time_params(::UniformTimeGrid)
+    # Multi-step steady-state still solves one time slice at a time
+    return 1, (1:1:1)
+end
+function _cache_time_params(time::RefinedTimeGrid)
     n_t = time.n_t_per_loop
     t_loop = range(0.0, step=time.dt_resolved, length=time.n_t_per_loop)
     return n_t, t_loop
 end
 
-# Compute input flux: dispatch on solver type
-_compute_input_flux(sim::AuroraSimulation) = _compute_input_flux(sim, sim.solver)
+# Compute input flux: dispatch on time config type
+_compute_input_flux(sim::AuroraSimulation) = _compute_input_flux(sim, sim.time)
 
-function _compute_input_flux(sim::AuroraSimulation, solver::SteadyStateSolver)
-    if is_multi_step(solver)
-        # Multi-step SS: compute flux at all time points (like TD)
-        return compute_flux(sim.flux, sim.model, sim.time.t)
-    else
-        # Single-step SS: no time grid
-        return compute_flux(sim.flux, sim.model)
-    end
-end
-function _compute_input_flux(sim::AuroraSimulation, ::TimeDependentSolver)
-    return compute_flux(sim.flux, sim.model, sim.time.t)
-end
+_compute_input_flux(sim::AuroraSimulation, ::SingleStepConfig) = compute_flux(sim.flux, sim.model)
+_compute_input_flux(sim::AuroraSimulation, time::UniformTimeGrid) = compute_flux(sim.flux, sim.model, time.t)
+_compute_input_flux(sim::AuroraSimulation, time::RefinedTimeGrid) = compute_flux(sim.flux, sim.model, time.t)
 
 # Number of time steps to save
-_save_time_length(sim::AuroraSimulation, t_loop) = _save_time_length(sim, sim.solver, t_loop)
+_save_time_length(sim::AuroraSimulation, t_loop) = _save_time_length(sim.time, t_loop)
 
-function _save_time_length(sim::AuroraSimulation, solver::SteadyStateSolver, t_loop)
-    # Multi-step SS: save all steps; single-step SS: save 1
-    return is_multi_step(solver) ? sim.time.n_steps : 1
-end
-function _save_time_length(sim::AuroraSimulation, ::TimeDependentSolver, t_loop)
-    time = sim.time::RefinedTimeGrid
-    return length(0:time.dt_requested:t_loop[end])
-end
+_save_time_length(::SingleStepConfig, t_loop) = 1
+_save_time_length(time::UniformTimeGrid, t_loop) = time.n_steps
+_save_time_length(time::RefinedTimeGrid, t_loop) = length(0:time.dt_requested:t_loop[end])
 
 # Compute phase functions for electron and ion scattering off neutral molecules (N2, O2, O).
 # These phase functions describe the angular distribution of particles after collisions.

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -21,9 +21,8 @@ function build_simulation_cache(sim::AuroraSimulation)
     neutral_densities = n_neutrals(model.ionosphere)
     n_E = model.energy_grid.n
 
-    # Set up time grid (single step for steady-state, multiple steps for time-dependent)
-    n_t = isnothing(sim.time) ? 1 : sim.time.n_t_per_loop
-    t_loop = isnothing(sim.time) ? (1:1:1) : range(0.0, step=sim.time.dt_resolved, length=sim.time.n_t_per_loop)
+    # Set up time grid dimensions for working arrays
+    n_t, t_loop = _cache_time_params(sim)
 
     # Initialize solver and physical process caches
     solver = SolverCache()
@@ -37,7 +36,7 @@ function build_simulation_cache(sim::AuroraSimulation)
     B2B_fragment = prepare_beams2beams(model.scattering.Ω_subbeam_relative, model.scattering.P_scatter)
 
     # Pre-compute input flux data
-    Ie_top = isnothing(sim.time) ? compute_flux(sim.flux, model) : compute_flux(sim.flux, model, sim.time.t)
+    Ie_top = _compute_input_flux(sim)
 
     # Bundle cascading functions for future easy access
     # TODO: can we do this in a more elegant way? Maybe we should have a dedicated struct?
@@ -49,11 +48,53 @@ function build_simulation_cache(sim::AuroraSimulation)
     # Initialize solution arrays
     I0 = zeros(length(z) * length(μ_center), n_E)
     Ie = zeros(length(z) * length(μ_center), n_t, n_E)
-    n_t_save = isnothing(sim.time) ? 1 : length(0:sim.time.dt_requested:t_loop[end])
+    n_t_save = _save_time_length(sim, t_loop)
     Ie_save = zeros(length(z) * length(μ_center), n_t_save, n_E)
 
     return SimulationCache(solver, degradation, matrices, Ie, Ie_save, I0, Ie_top,
                            t_loop, phase_fcn_neutrals, B2B_fragment, cascading_neutrals)
+end
+
+# Time parameters for working arrays: (n_t, t_loop)
+_cache_time_params(sim::AuroraSimulation) = _cache_time_params(sim, sim.solver)
+
+function _cache_time_params(sim::AuroraSimulation, ::SteadyStateSolver)
+    # Both single-step and multi-step SS solve one time slice at a time
+    return 1, (1:1:1)
+end
+function _cache_time_params(sim::AuroraSimulation, ::TimeDependentSolver)
+    time = sim.time::RefinedTimeGrid
+    n_t = time.n_t_per_loop
+    t_loop = range(0.0, step=time.dt_resolved, length=time.n_t_per_loop)
+    return n_t, t_loop
+end
+
+# Compute input flux: dispatch on solver type
+_compute_input_flux(sim::AuroraSimulation) = _compute_input_flux(sim, sim.solver)
+
+function _compute_input_flux(sim::AuroraSimulation, solver::SteadyStateSolver)
+    if is_multi_step(solver)
+        # Multi-step SS: compute flux at all time points (like TD)
+        return compute_flux(sim.flux, sim.model, sim.time.t)
+    else
+        # Single-step SS: no time grid
+        return compute_flux(sim.flux, sim.model)
+    end
+end
+function _compute_input_flux(sim::AuroraSimulation, ::TimeDependentSolver)
+    return compute_flux(sim.flux, sim.model, sim.time.t)
+end
+
+# Number of time steps to save
+_save_time_length(sim::AuroraSimulation, t_loop) = _save_time_length(sim, sim.solver, t_loop)
+
+function _save_time_length(sim::AuroraSimulation, solver::SteadyStateSolver, t_loop)
+    # Multi-step SS: save all steps; single-step SS: save 1
+    return is_multi_step(solver) ? sim.time.n_steps : 1
+end
+function _save_time_length(sim::AuroraSimulation, ::TimeDependentSolver, t_loop)
+    time = sim.time::RefinedTimeGrid
+    return length(0:time.dt_requested:t_loop[end])
 end
 
 # Compute phase functions for electron and ion scattering off neutral molecules (N2, O2, O).

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -11,7 +11,7 @@ appropriate execution path based on the selected mode.
 # Examples
 ```julia
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(duration=0.5, dt=0.001, CFL_number=128))
 run!(sim)
 ```
 """

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -35,6 +35,7 @@ function _solve!(sim::AuroraSimulation, ::TimeDependentSolver)
     @info "Starting time-dependent simulation..."
     cache = get_cache(sim)
     time = sim.time::RefinedTimeGrid
+    n_E = sim.model.energy_grid.n
 
     fill!(cache.I0, 0.0)
     fill!(cache.Ie, 0.0)
@@ -51,8 +52,11 @@ function _solve!(sim::AuroraSimulation, ::TimeDependentSolver)
         i_start = 1 + (i_loop - 1) * (time.n_t_per_loop - 1)
         i_stop = time.n_t_per_loop + (i_loop - 1) * (time.n_t_per_loop - 1)
         Ie_top_local = @view cache.Ie_top[:, i_start:i_stop, :]
+        progress = Progress(n_E;
+                    desc=string("Solving [loop ", i_loop, "/", time.n_loop, "]"),
+                    dt=1.0)
 
-        energy_loop!(sim, Ie_top_local, i_loop, time.n_loop)
+        energy_loop!(sim, Ie_top_local, progress)
 
         # Save current loop final state to I0 for continuity to next loop
         cache.I0 .= cache.Ie[:, end, :]
@@ -78,13 +82,15 @@ end
 function _solve_single_step_steady_state!(sim::AuroraSimulation)
     @info "Starting single-step steady-state simulation..."
     cache = get_cache(sim)
+    n_E = sim.model.energy_grid.n
 
     fill!(cache.I0, 0.0)
     fill!(cache.Ie, 0.0)
     fill!(cache.matrices.Q, 0.0)
 
     Ie_top_local = @view cache.Ie_top[:, 1, :]
-    energy_loop!(sim, Ie_top_local, 1, 1)
+    progress = Progress(n_E; desc="Solving", dt=1.0)
+    energy_loop!(sim, Ie_top_local, progress)
     save_results(sim, cache.Ie, cache.t_loop, cache.I0, 1, 1)
 
     return sim
@@ -94,6 +100,8 @@ function _solve_multi_step_steady_state!(sim::AuroraSimulation)
     @info "Starting multi-step steady-state simulation..."
     cache = get_cache(sim)
     time = sim.time::UniformTimeGrid
+    n_E = sim.model.energy_grid.n
+    progress = Progress(time.n_steps * n_E; desc="Solving", dt=1.0)
 
     for i_step in 1:time.n_steps
         # Reset state for each independent step
@@ -103,25 +111,22 @@ function _solve_multi_step_steady_state!(sim::AuroraSimulation)
 
         # Extract the boundary condition for this time step
         Ie_top_local = @view cache.Ie_top[:, i_step, :]
-        energy_loop!(sim, Ie_top_local, i_step, time.n_steps)
+        energy_loop!(sim, Ie_top_local, progress)
 
         # Accumulate result into the save array
         cache.Ie_save[:, i_step, :] .= @view cache.Ie[:, 1, :]
     end
 
     # Save all steps to a single file
-    save_results(sim, cache.Ie_save, cache.t_loop, cache.I0, 1, 1)
+    save_results(sim, cache.Ie_save, time.t, cache.I0, 1, 1)
 
     return sim
 end
 
-function energy_loop!(sim::AuroraSimulation, Ie_top_local, i_loop::Int, n_loop::Int)
+function energy_loop!(sim::AuroraSimulation, Ie_top_local, progress::Progress)
     cache = get_cache(sim)
     model = sim.model
-    E_centers = model.energy_grid.E_centers
     n_E = model.energy_grid.n
-
-    progress = Progress(n_E; desc=string("Calculating flux for step ", i_loop, "/", n_loop), dt=1.0)
 
     # Energy loop: solve transport in descending energy order.
     # High-to-low ensures cascading sources are available when solving lower energies.

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -6,11 +6,12 @@ using ProgressMeter: Progress, next!
 Execute the simulation described by `sim`.
 
 Automatically calls [`initialize!`](@ref) when needed, then dispatches to the
-time-dependent or steady-state execution path.
+appropriate execution path based on the solver type.
 
 # Examples
 ```julia
-sim = AuroraSimulation(model, flux, 0.5, 0.001, savedir)
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
 run!(sim)
 ```
 """
@@ -19,7 +20,8 @@ function run!(sim::AuroraSimulation)
         initialize!(sim)
     end
     if sim.save_input_flux
-        save_Ie_top(sim, sim.cache.Ie_top, isnothing(sim.time) ? (1:1:1) : sim.time.t)
+        t_save = isnothing(sim.time) ? (1:1:1) : sim.time.t
+        save_Ie_top(sim, sim.cache.Ie_top, t_save)
     end
     save_parameters(sim)
     save_neutrals(sim)
@@ -27,19 +29,12 @@ function run!(sim::AuroraSimulation)
     return sim
 end
 
-function solve!(sim::AuroraSimulation)
-    @info "Starting simulation..."
-    if isnothing(sim.time)
-        solve_steady_state!(sim)
-    else
-        solve_time_dependent!(sim)
-    end
-    return sim
-end
+solve!(sim::AuroraSimulation) = _solve!(sim, sim.solver)
 
-function solve_time_dependent!(sim::AuroraSimulation)
+function _solve!(sim::AuroraSimulation, ::TimeDependentSolver)
+    @info "Starting time-dependent simulation..."
     cache = get_cache(sim)
-    time = sim.time
+    time = sim.time::RefinedTimeGrid
 
     fill!(cache.I0, 0.0)
     fill!(cache.Ie, 0.0)
@@ -71,7 +66,17 @@ function solve_time_dependent!(sim::AuroraSimulation)
     return sim
 end
 
-function solve_steady_state!(sim::AuroraSimulation)
+function _solve!(sim::AuroraSimulation, solver::SteadyStateSolver)
+    if is_multi_step(solver)
+        _solve_multi_step_steady_state!(sim)
+    else
+        _solve_single_step_steady_state!(sim)
+    end
+    return sim
+end
+
+function _solve_single_step_steady_state!(sim::AuroraSimulation)
+    @info "Starting single-step steady-state simulation..."
     cache = get_cache(sim)
 
     fill!(cache.I0, 0.0)
@@ -85,15 +90,38 @@ function solve_steady_state!(sim::AuroraSimulation)
     return sim
 end
 
+function _solve_multi_step_steady_state!(sim::AuroraSimulation)
+    @info "Starting multi-step steady-state simulation..."
+    cache = get_cache(sim)
+    time = sim.time::UniformTimeGrid
+
+    for i_step in 1:time.n_steps
+        # Reset state for each independent step
+        fill!(cache.I0, 0.0)
+        fill!(cache.Ie, 0.0)
+        fill!(cache.matrices.Q, 0.0)
+
+        # Extract the boundary condition for this time step
+        Ie_top_local = @view cache.Ie_top[:, i_step, :]
+        energy_loop!(sim, Ie_top_local, i_step, time.n_steps)
+
+        # Accumulate result into the save array
+        cache.Ie_save[:, i_step, :] .= @view cache.Ie[:, 1, :]
+    end
+
+    # Save all steps to a single file
+    save_results(sim, cache.Ie_save, cache.t_loop, cache.I0, 1, 1)
+
+    return sim
+end
+
 function energy_loop!(sim::AuroraSimulation, Ie_top_local, i_loop::Int, n_loop::Int)
     cache = get_cache(sim)
     model = sim.model
     E_centers = model.energy_grid.E_centers
     n_E = model.energy_grid.n
 
-    progress = isnothing(sim.time) ?
-               Progress(n_E, desc="Calculating flux",  dt=1.0) :
-               Progress(n_E; desc=string("Calculating flux for loop ", i_loop, "/", n_loop), dt=1.0)
+    progress = Progress(n_E; desc=string("Calculating flux for step ", i_loop, "/", n_loop), dt=1.0)
 
     # Energy loop: solve transport in descending energy order.
     # High-to-low ensures cascading sources are available when solving lower energies.
@@ -104,7 +132,7 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, i_loop::Int, n_loop::
                                                   cache.B2B_fragment)
 
         # Solve transport equation for current energy
-        solve_energy_step!(sim, iE, Ie_top_local; first_iteration=(iE == n_E))
+        _solve_energy_step!(sim, sim.solver, iE, Ie_top_local; first_iteration=(iE == n_E))
 
         # Update source term Q for lower energies from current energy's:
         # - inelastic scattering collisions → degradation → lower energies
@@ -119,23 +147,28 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, i_loop::Int, n_loop::
     return sim
 end
 
-function solve_energy_step!(sim::AuroraSimulation, iE::Int, Ie_top_local; first_iteration=false)
+function _solve_energy_step!(sim::AuroraSimulation, ::SteadyStateSolver,
+                             iE::Int, Ie_top_local; first_iteration=false)
     cache = get_cache(sim)
     model = sim.model
 
-    if isnothing(sim.time)
-        @views steady_state_scheme_optimized!(cache.Ie[:, 1, iE], model,
-                                              cache.matrices, iE,
-                                              Ie_top_local[:, iE], cache.solver;
-                                              first_iteration)
-    else
-        @views Crank_Nicolson_optimized!(cache.Ie[:, :, iE], cache.t_loop, model,
-                                         v_of_E(model.energy_grid.E_centers[iE]),
-                                         cache.matrices, iE,
-                                         Ie_top_local[:, :, iE], cache.I0[:, iE],
-                                         cache.solver; first_iteration)
-    end
+    @views steady_state_scheme_optimized!(cache.Ie[:, 1, iE], model,
+                                          cache.matrices, iE,
+                                          Ie_top_local[:, iE], cache.solver;
+                                          first_iteration)
+    return sim
+end
 
+function _solve_energy_step!(sim::AuroraSimulation, ::TimeDependentSolver,
+                             iE::Int, Ie_top_local; first_iteration=false)
+    cache = get_cache(sim)
+    model = sim.model
+
+    @views Crank_Nicolson_optimized!(cache.Ie[:, :, iE], cache.t_loop, model,
+                                     v_of_E(model.energy_grid.E_centers[iE]),
+                                     cache.matrices, iE,
+                                     Ie_top_local[:, :, iE], cache.I0[:, iE],
+                                     cache.solver; first_iteration)
     return sim
 end
 

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -6,12 +6,12 @@ using ProgressMeter: Progress, next!
 Execute the simulation described by `sim`.
 
 Automatically calls [`initialize!`](@ref) when needed, then dispatches to the
-appropriate execution path based on the solver type.
+appropriate execution path based on the selected mode.
 
 # Examples
 ```julia
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
 run!(sim)
 ```
 """
@@ -20,7 +20,7 @@ function run!(sim::AuroraSimulation)
         initialize!(sim)
     end
     if sim.save_input_flux
-        t_save = isnothing(sim.time) ? (1:1:1) : sim.time.t
+        t_save = _save_time_axis(sim.time)
         save_Ie_top(sim, sim.cache.Ie_top, t_save)
     end
     save_parameters(sim)
@@ -29,9 +29,13 @@ function run!(sim::AuroraSimulation)
     return sim
 end
 
-solve!(sim::AuroraSimulation) = _solve!(sim, sim.solver)
+_save_time_axis(::SingleStepConfig) = (1:1:1)
+_save_time_axis(time::UniformTimeGrid) = time.t
+_save_time_axis(time::RefinedTimeGrid) = time.t
 
-function _solve!(sim::AuroraSimulation, ::TimeDependentSolver)
+solve!(sim::AuroraSimulation) = _solve!(sim, sim.mode)
+
+function _solve!(sim::AuroraSimulation, ::TimeDependentMode)
     @info "Starting time-dependent simulation..."
     cache = get_cache(sim)
     time = sim.time::RefinedTimeGrid
@@ -70,14 +74,9 @@ function _solve!(sim::AuroraSimulation, ::TimeDependentSolver)
     return sim
 end
 
-function _solve!(sim::AuroraSimulation, solver::SteadyStateSolver)
-    if is_multi_step(solver)
-        _solve_multi_step_steady_state!(sim)
-    else
-        _solve_single_step_steady_state!(sim)
-    end
-    return sim
-end
+_solve!(sim::AuroraSimulation, ::SteadyStateMode) = _solve!(sim, sim.time)
+_solve!(sim::AuroraSimulation, ::SingleStepConfig)  = _solve_single_step_steady_state!(sim)
+_solve!(sim::AuroraSimulation, ::UniformTimeGrid)   = _solve_multi_step_steady_state!(sim)
 
 function _solve_single_step_steady_state!(sim::AuroraSimulation)
     @info "Starting single-step steady-state simulation..."
@@ -137,7 +136,7 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, progress::Progress)
                                                   cache.B2B_fragment)
 
         # Solve transport equation for current energy
-        _solve_energy_step!(sim, sim.solver, iE, Ie_top_local; first_iteration=(iE == n_E))
+        _solve_energy_step!(sim, sim.mode, iE, Ie_top_local; first_iteration=(iE == n_E))
 
         # Update source term Q for lower energies from current energy's:
         # - inelastic scattering collisions → degradation → lower energies
@@ -152,7 +151,7 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, progress::Progress)
     return sim
 end
 
-function _solve_energy_step!(sim::AuroraSimulation, ::SteadyStateSolver,
+function _solve_energy_step!(sim::AuroraSimulation, ::SteadyStateMode,
                              iE::Int, Ie_top_local; first_iteration=false)
     cache = get_cache(sim)
     model = sim.model
@@ -164,7 +163,7 @@ function _solve_energy_step!(sim::AuroraSimulation, ::SteadyStateSolver,
     return sim
 end
 
-function _solve_energy_step!(sim::AuroraSimulation, ::TimeDependentSolver,
+function _solve_energy_step!(sim::AuroraSimulation, ::TimeDependentMode,
                              iE::Int, Ie_top_local; first_iteration=false)
     cache = get_cache(sim)
     model = sim.model

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -51,11 +51,7 @@ function UniformTimeGrid(duration, dt)
     dt > 0 || error("dt must be positive, got $dt")
     dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
 
-    n_intervals = Float64(duration) / Float64(dt)
-    n_intervals_round = round(Int, n_intervals)
-    isapprox(n_intervals, n_intervals_round; atol=1e-10, rtol=1e-10) ||
-        error("duration ($duration) must be an integer multiple of dt ($dt)")
-
+    n_intervals_round = round(Int, Float64(duration) / Float64(dt))
     n_steps = n_intervals_round + 1
     t = range(0.0, stop=Float64(duration), length=n_steps)
     return UniformTimeGrid(Float64(duration), Float64(dt), t, n_steps)

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -1,16 +1,79 @@
 """
-    AbstractTimeGrid
+    AbstractTimeConfig
 
-Abstract supertype for time grids used by simulations.
+Abstract supertype for resolved time configurations used by simulations.
 
 Concrete subtypes:
-- [`RefinedTimeGrid`](@ref): CFL-refined grid for time-dependent simulations
+- [`SingleStepConfig`](@ref): explicit single-step configuration for steady-state simulations
 - [`UniformTimeGrid`](@ref): simple uniform grid for multi-step steady-state simulations
+- [`RefinedTimeGrid`](@ref): CFL-refined grid for time-dependent simulations
 """
-abstract type AbstractTimeGrid end
+abstract type AbstractTimeConfig end
 
-struct RefinedTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeGrid
-    t_total::Float64
+"""
+    SingleStepConfig()
+
+Explicit single-step time configuration.
+
+Used for steady-state simulations without temporal evolution.
+"""
+struct SingleStepConfig <: AbstractTimeConfig
+    t::UnitRange{Int}
+    n_steps::Int
+end
+
+SingleStepConfig() = SingleStepConfig(1:1, 1)
+
+function Base.show(io::IO, ::SingleStepConfig)
+    print(io, "SingleStepConfig()")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", ::SingleStepConfig)
+    print(io, "SingleStepConfig (single-step)")
+end
+
+"""
+    UniformTimeGrid(duration, dt)
+
+A simple uniform time grid for multi-step steady-state simulations.
+
+Each time point is solved independently — no CFL refinement or loop splitting is needed.
+"""
+struct UniformTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeConfig
+    duration::Float64
+    dt::Float64
+    t::T
+    n_steps::Int
+end
+
+function UniformTimeGrid(duration, dt)
+    duration > 0 || error("duration must be positive, got $duration")
+    dt > 0 || error("dt must be positive, got $dt")
+    dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
+
+    n_intervals = Float64(duration) / Float64(dt)
+    n_intervals_round = round(Int, n_intervals)
+    isapprox(n_intervals, n_intervals_round; atol=1e-10, rtol=1e-10) ||
+        error("duration ($duration) must be an integer multiple of dt ($dt)")
+
+    n_steps = n_intervals_round + 1
+    t = range(0.0, stop=Float64(duration), length=n_steps)
+    return UniformTimeGrid(Float64(duration), Float64(dt), t, n_steps)
+end
+
+function Base.show(io::IO, time::UniformTimeGrid)
+    print(io, "UniformTimeGrid(duration=$(time.duration), dt=$(time.dt), n_steps=$(time.n_steps))")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", time::UniformTimeGrid)
+    println(io, "UniformTimeGrid:")
+    println(io, "├── Duration:   ", time.duration, " s")
+    println(io, "├── dt:         ", time.dt, " s")
+    print(io,   "└── n_steps:    ", time.n_steps)
+end
+
+struct RefinedTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeConfig
+    duration::Float64
     dt_requested::Float64
     dt_resolved::Float64
     CFL_factor::Int
@@ -19,12 +82,12 @@ struct RefinedTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeGrid
     n_t_per_loop::Int
 end
 
-function RefinedTimeGrid(model::AuroraModel, solver::TimeDependentSolver)
-    t_total = solver.t_total
-    dt = solver.dt
-    CFL_number = solver.CFL_number
-    max_memory_gb = solver.max_memory_gb
-    n_loop = solver.n_loop
+function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode)
+    duration = mode.duration
+    dt = mode.dt
+    CFL_number = mode.CFL_number
+    max_memory_gb = mode.max_memory_gb
+    n_loop = mode.n_loop
 
     # Extract grid dimensions from the model
     z = model.altitude_grid.h
@@ -33,7 +96,7 @@ function RefinedTimeGrid(model::AuroraModel, solver::TimeDependentSolver)
     v_max = v_of_E(maximum(model.energy_grid.E_centers))
 
     # Apply CFL criteria to resolve the time grid and calculate CFL factor
-    t_resolved, CFL_factor = CFL_criteria(t_total, dt, z, v_max, CFL_number)
+    t_resolved, CFL_factor = CFL_criteria(duration, dt, z, v_max, CFL_number)
     # Determine number of loops based on memory constraints, or use provided value
     n_loop_resolved = isnothing(n_loop) ? calculate_n_loop(t_resolved, length(z), n_μ, n_E;
                                                            max_memory_gb=max_memory_gb) : Int(n_loop)
@@ -45,17 +108,17 @@ function RefinedTimeGrid(model::AuroraModel, solver::TimeDependentSolver)
     dt_resolved = length(t_resolved) > 1 ? Float64(t_resolved[2] - t_resolved[1]) : Float64(dt)
 
     # Return fully configured time grid
-    return RefinedTimeGrid(Float64(t_total), Float64(dt), dt_resolved,
+    return RefinedTimeGrid(Float64(duration), Float64(dt), dt_resolved,
                             CFL_factor, t_resolved, n_loop_resolved, n_t_per_loop)
 end
 
 function Base.show(io::IO, time::RefinedTimeGrid)
-    print(io, "RefinedTimeGrid(t_total=$(time.t_total), dt=$(time.dt_requested), n_loop=$(time.n_loop))")
+    print(io, "RefinedTimeGrid(duration=$(time.duration), dt=$(time.dt_requested), n_loop=$(time.n_loop))")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", time::RefinedTimeGrid)
     println(io, "RefinedTimeGrid:")
-    println(io, "├── Total time:    ", time.t_total, " s")
+    println(io, "├── Duration:      ", time.duration, " s")
     println(io, "├── Requested dt:  ", time.dt_requested, " s")
     println(io, "├── Resolved dt:   ", time.dt_resolved, " s")
     println(io, "├── CFL factor:    ", time.CFL_factor)
@@ -63,41 +126,12 @@ function Base.show(io::IO, ::MIME"text/plain", time::RefinedTimeGrid)
     print(io,   "└── steps / loop:  ", time.n_t_per_loop)
 end
 
-"""
-    UniformTimeGrid(t_total, dt)
-
-A simple uniform time grid for multi-step steady-state simulations.
-
-Each time point is solved independently — no CFL refinement or loop splitting is needed.
-"""
-struct UniformTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeGrid
-    t_total::Float64
-    dt::Float64
-    t::T
-    n_steps::Int
-end
-
-function UniformTimeGrid(t_total, dt)
-    t = range(0, Float64(t_total), step=Float64(dt))
-    return UniformTimeGrid(Float64(t_total), Float64(dt), t, length(t))
-end
-
-function Base.show(io::IO, time::UniformTimeGrid)
-    print(io, "UniformTimeGrid(t_total=$(time.t_total), dt=$(time.dt), n_steps=$(time.n_steps))")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", time::UniformTimeGrid)
-    println(io, "UniformTimeGrid:")
-    println(io, "├── Total time: ", time.t_total, " s")
-    println(io, "├── dt:         ", time.dt, " s")
-    print(io,   "└── n_steps:    ", time.n_steps)
-end
 
 """
-    AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractSolver}
+    AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractMode}
 
 A complete simulation configuration, bundling the physical model, input flux,
-solver strategy, output directory, resolved time grid, and lazy simulation cache.
+mode strategy, output directory, resolved time configuration, and lazy simulation cache.
 
 Use [`initialize!`](@ref) to allocate the workspace explicitly, or call [`run!`](@ref)
 directly to auto-initialize and execute the simulation.
@@ -105,64 +139,68 @@ directly to auto-initialize and execute the simulation.
 # Examples
 ```julia
 # Single-step steady-state
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
 # Multi-step steady-state
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.5, 0.01))
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.5, 0.01))
 
 # Time-dependent
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
 ```
 """
-mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractSolver}
+mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractMode}
     const model::M
     const flux::F
-    const solver::S
+    const mode::S
     const savedir::String
-    const time::Union{AbstractTimeGrid, Nothing}
+    const time::AbstractTimeConfig
     const save_input_flux::Bool
     cache::Union{Nothing, SimulationCache}
 end
 
 function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir;
-                          solver::AbstractSolver=SteadyStateSolver(),
+                          mode::AbstractMode=SteadyStateMode(),
                           save_input_flux=true)
-    time = _build_time_grid(model, solver)
-    return AuroraSimulation(model, flux, solver, String(savedir), time, save_input_flux, nothing)
+    time = _build_time_config(model, mode)
+    return AuroraSimulation(model, flux, mode, String(savedir), time, save_input_flux, nothing)
 end
 
-# Build the appropriate time grid based on the solver type
-_build_time_grid(model::AuroraModel, solver::SteadyStateSolver) =
-    is_multi_step(solver) ? UniformTimeGrid(solver.t_total, solver.dt) : nothing
-_build_time_grid(model::AuroraModel, solver::TimeDependentSolver) =
-    RefinedTimeGrid(model, solver)
+# Build the appropriate time configuration based on the mode
+_build_time_config(model::AuroraModel, mode::SteadyStateMode) =
+    is_multi_step(mode) ? UniformTimeGrid(mode.duration, mode.dt) : SingleStepConfig()
+_build_time_config(model::AuroraModel, mode::TimeDependentMode) =
+    RefinedTimeGrid(model, mode)
 
 function Base.show(io::IO, sim::AuroraSimulation)
-    mode = sim.solver isa SteadyStateSolver ? "steady-state" : "time-dependent"
-    print(io, "AuroraSimulation($mode)")
+    mode_name = sim.mode isa SteadyStateMode ? "steady-state" : "time-dependent"
+    print(io, "AuroraSimulation($mode_name)")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", sim::AuroraSimulation)
-    mode = sim.solver isa SteadyStateSolver ? "Steady-state" : "Time-dependent"
-    println(io, "AuroraSimulation ($mode):")
+    mode_name = sim.mode isa SteadyStateMode ? "Steady-state" : "Time-dependent"
+    println(io, "AuroraSimulation ($mode_name):")
     println(io, "├── Model:       ", sim.model)
     println(io, "├── Flux:        ", sim.flux)
-    println(io, "├── Solver:      ", sim.solver)
+    println(io, "├── Mode:        ", sim.mode)
     println(io, "├── Savedir:     ", sim.savedir)
-    if sim.time isa RefinedTimeGrid
-        println(io, "├── t_total:     ", sim.time.t_total, " s")
-        println(io, "├── dt request:  ", sim.time.dt_requested, " s")
-        println(io, "├── dt resolved: ", sim.time.dt_resolved, " s")
-        println(io, "├── CFL factor:  ", sim.time.CFL_factor)
-        println(io, "├── n_loop:      ", sim.time.n_loop)
-    elseif sim.time isa UniformTimeGrid
-        println(io, "├── t_total:     ", sim.time.t_total, " s")
-        println(io, "├── dt:          ", sim.time.dt, " s")
-        println(io, "├── n_steps:     ", sim.time.n_steps)
-    else
-        println(io, "├── Time:        single-step")
-    end
+    _show_time_fields(io, sim.time)
     println(io, "├── Cache:       ", sim.cache === nothing ? "not initialized" : "initialized")
     print(io,   "└── Save flux:   ", sim.save_input_flux)
+end
+
+function _show_time_fields(io::IO, time::RefinedTimeGrid)
+    println(io, "├── duration:    ", time.duration, " s")
+    println(io, "├── dt request:  ", time.dt_requested, " s")
+    println(io, "├── dt resolved: ", time.dt_resolved, " s")
+    println(io, "├── CFL factor:  ", time.CFL_factor)
+    println(io, "├── n_loop:      ", time.n_loop)
+end
+function _show_time_fields(io::IO, time::UniformTimeGrid)
+    println(io, "├── duration:    ", time.duration, " s")
+    println(io, "├── dt:          ", time.dt, " s")
+    println(io, "├── n_steps:     ", time.n_steps)
+end
+function _show_time_fields(io::IO, ::SingleStepConfig)
+    println(io, "├── Time:        single-step")
 end

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -1,26 +1,30 @@
-struct ResolvedTimeGrid{T<:AbstractRange{Float64}}
+"""
+    AbstractTimeGrid
+
+Abstract supertype for time grids used by simulations.
+
+Concrete subtypes:
+- [`RefinedTimeGrid`](@ref): CFL-refined grid for time-dependent simulations
+- [`UniformTimeGrid`](@ref): simple uniform grid for multi-step steady-state simulations
+"""
+abstract type AbstractTimeGrid end
+
+struct RefinedTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeGrid
     t_total::Float64
     dt_requested::Float64
     dt_resolved::Float64
-    CFL_number::Float64
     CFL_factor::Int
     t::T
     n_loop::Int
-    max_memory_gb::Float64
     n_t_per_loop::Int
 end
 
-function ResolvedTimeGrid(model::AuroraModel, t_total, dt;
-                          CFL_number=64, n_loop=nothing, max_memory_gb=8.0)
-    # Validate all input parameters
-    t_total > 0 || error("t_total must be positive, got $t_total")
-    dt > 0 || error("dt must be positive, got $dt")
-    dt <= t_total || error("dt ($dt) must be ≤ t_total ($t_total)")
-    CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
-    max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
-    if !isnothing(n_loop)
-        n_loop > 0 || error("n_loop must be positive, got $n_loop")
-    end
+function RefinedTimeGrid(model::AuroraModel, solver::TimeDependentSolver)
+    t_total = solver.t_total
+    dt = solver.dt
+    CFL_number = solver.CFL_number
+    max_memory_gb = solver.max_memory_gb
+    n_loop = solver.n_loop
 
     # Extract grid dimensions from the model
     z = model.altitude_grid.h
@@ -41,76 +45,123 @@ function ResolvedTimeGrid(model::AuroraModel, t_total, dt;
     dt_resolved = length(t_resolved) > 1 ? Float64(t_resolved[2] - t_resolved[1]) : Float64(dt)
 
     # Return fully configured time grid
-    return ResolvedTimeGrid(Float64(t_total), Float64(dt), dt_resolved, Float64(CFL_number),
-                            CFL_factor, t_resolved, n_loop_resolved,
-                            Float64(max_memory_gb), n_t_per_loop)
+    return RefinedTimeGrid(Float64(t_total), Float64(dt), dt_resolved,
+                            CFL_factor, t_resolved, n_loop_resolved, n_t_per_loop)
 end
 
-function Base.show(io::IO, time::ResolvedTimeGrid)
-    print(io, "ResolvedTimeGrid(t_total=$(time.t_total), dt=$(time.dt_requested), n_loop=$(time.n_loop))")
+function Base.show(io::IO, time::RefinedTimeGrid)
+    print(io, "RefinedTimeGrid(t_total=$(time.t_total), dt=$(time.dt_requested), n_loop=$(time.n_loop))")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", time::ResolvedTimeGrid)
-    println(io, "ResolvedTimeGrid:")
+function Base.show(io::IO, ::MIME"text/plain", time::RefinedTimeGrid)
+    println(io, "RefinedTimeGrid:")
     println(io, "├── Total time:    ", time.t_total, " s")
     println(io, "├── Requested dt:  ", time.dt_requested, " s")
     println(io, "├── Resolved dt:   ", time.dt_resolved, " s")
-    println(io, "├── CFL number:    ", time.CFL_number)
     println(io, "├── CFL factor:    ", time.CFL_factor)
     println(io, "├── n_loop:        ", time.n_loop)
-    println(io, "├── steps / loop:  ", time.n_t_per_loop)
-    print(io,   "└── memory budget: ", time.max_memory_gb, " GB")
+    print(io,   "└── steps / loop:  ", time.n_t_per_loop)
 end
 
 """
-    AuroraSimulation{M<:AuroraModel, F<:InputFlux}
+    UniformTimeGrid(t_total, dt)
+
+A simple uniform time grid for multi-step steady-state simulations.
+
+Each time point is solved independently — no CFL refinement or loop splitting is needed.
+"""
+struct UniformTimeGrid{T<:AbstractRange{Float64}} <: AbstractTimeGrid
+    t_total::Float64
+    dt::Float64
+    t::T
+    n_steps::Int
+end
+
+function UniformTimeGrid(t_total, dt)
+    t = range(0, Float64(t_total), step=Float64(dt))
+    return UniformTimeGrid(Float64(t_total), Float64(dt), t, length(t))
+end
+
+function Base.show(io::IO, time::UniformTimeGrid)
+    print(io, "UniformTimeGrid(t_total=$(time.t_total), dt=$(time.dt), n_steps=$(time.n_steps))")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", time::UniformTimeGrid)
+    println(io, "UniformTimeGrid:")
+    println(io, "├── Total time: ", time.t_total, " s")
+    println(io, "├── dt:         ", time.dt, " s")
+    print(io,   "└── n_steps:    ", time.n_steps)
+end
+
+"""
+    AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractSolver}
 
 A complete simulation configuration, bundling the physical model, input flux,
-output directory, resolved time grid, and lazy simulation cache.
+solver strategy, output directory, resolved time grid, and lazy simulation cache.
 
 Use [`initialize!`](@ref) to allocate the workspace explicitly, or call [`run!`](@ref)
 directly to auto-initialize and execute the simulation.
+
+# Examples
+```julia
+# Single-step steady-state
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+
+# Multi-step steady-state
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.5, 0.01))
+
+# Time-dependent
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+```
 """
-mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux}
+mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractSolver}
     const model::M
     const flux::F
+    const solver::S
     const savedir::String
-    const time::Union{ResolvedTimeGrid, Nothing}
+    const time::Union{AbstractTimeGrid, Nothing}
     const save_input_flux::Bool
     cache::Union{Nothing, SimulationCache}
 end
 
-function AuroraSimulation(model::AuroraModel, flux::InputFlux, t_total, dt, savedir;
-                          CFL_number=64, n_loop=nothing, max_memory_gb=8.0,
+function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir;
+                          solver::AbstractSolver=SteadyStateSolver(),
                           save_input_flux=true)
-    time = ResolvedTimeGrid(model, t_total, dt; CFL_number, n_loop, max_memory_gb)
-    return AuroraSimulation(model, flux, String(savedir), time, save_input_flux, nothing)
+    time = _build_time_grid(model, solver)
+    return AuroraSimulation(model, flux, solver, String(savedir), time, save_input_flux, nothing)
 end
 
-function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir;
-                          save_input_flux=true)
-    return AuroraSimulation(model, flux, String(savedir), nothing, save_input_flux, nothing)
-end
+# Build the appropriate time grid based on the solver type
+_build_time_grid(model::AuroraModel, solver::SteadyStateSolver) =
+    is_multi_step(solver) ? UniformTimeGrid(solver.t_total, solver.dt) : nothing
+_build_time_grid(model::AuroraModel, solver::TimeDependentSolver) =
+    RefinedTimeGrid(model, solver)
 
 function Base.show(io::IO, sim::AuroraSimulation)
-    mode = isnothing(sim.time) ? "steady-state" : "time-dependent"
+    mode = sim.solver isa SteadyStateSolver ? "steady-state" : "time-dependent"
     print(io, "AuroraSimulation($mode)")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", sim::AuroraSimulation)
-    mode = isnothing(sim.time) ? "Steady-state" : "Time-dependent"
+    mode = sim.solver isa SteadyStateSolver ? "Steady-state" : "Time-dependent"
     println(io, "AuroraSimulation ($mode):")
     println(io, "├── Model:       ", sim.model)
     println(io, "├── Flux:        ", sim.flux)
+    println(io, "├── Solver:      ", sim.solver)
     println(io, "├── Savedir:     ", sim.savedir)
-    if isnothing(sim.time)
-        println(io, "├── Time:        steady-state")
-    else
+    if sim.time isa RefinedTimeGrid
         println(io, "├── t_total:     ", sim.time.t_total, " s")
         println(io, "├── dt request:  ", sim.time.dt_requested, " s")
         println(io, "├── dt resolved: ", sim.time.dt_resolved, " s")
-        println(io, "├── CFL:         ", sim.time.CFL_number)
+        println(io, "├── CFL factor:  ", sim.time.CFL_factor)
         println(io, "├── n_loop:      ", sim.time.n_loop)
+    elseif sim.time isa UniformTimeGrid
+        println(io, "├── t_total:     ", sim.time.t_total, " s")
+        println(io, "├── dt:          ", sim.time.dt, " s")
+        println(io, "├── n_steps:     ", sim.time.n_steps)
+    else
+        println(io, "├── Time:        single-step")
     end
     println(io, "├── Cache:       ", sim.cache === nothing ? "not initialized" : "initialized")
     print(io,   "└── Save flux:   ", sim.save_input_flux)

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -142,11 +142,11 @@ directly to auto-initialize and execute the simulation.
 sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
 # Multi-step steady-state
-sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.5, 0.01))
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration=0.5, dt=0.01))
 
 # Time-dependent
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(duration=0.5, dt=0.001, CFL_number=128))
 ```
 """
 mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractMode}

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -37,15 +37,19 @@ sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration=0.5, 
 struct SteadyStateMode <: AbstractMode
     duration::Union{Nothing, Float64}
     dt::Union{Nothing, Float64}
+end
 
-    SteadyStateMode() = new(nothing, nothing)
-
-    function SteadyStateMode(; duration, dt)
-        duration > 0 || error("duration must be positive, got $duration")
-        dt > 0 || error("dt must be positive, got $dt")
-        dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
-        return new(Float64(duration), Float64(dt))
+function SteadyStateMode(; duration=nothing, dt=nothing)
+    if isnothing(duration) && isnothing(dt)
+        return SteadyStateMode(nothing, nothing)
     end
+    isnothing(duration) && error("duration is missing (dt=$dt was provided)")
+    isnothing(dt) && error("dt is missing (duration=$duration was provided)")
+    duration > 0 || error("duration must be positive, got $duration")
+    dt > 0 || error("dt must be positive, got $dt")
+    dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
+    mod(duration, dt) > 1e-10 * dt && error("duration ($duration) must be an integer multiple of dt ($dt)")
+    return SteadyStateMode(Float64(duration), Float64(dt))
 end
 
 """
@@ -95,9 +99,7 @@ struct TimeDependentMode <: AbstractMode
         duration > 0 || error("duration must be positive, got $duration")
         dt > 0 || error("dt must be positive, got $dt")
         dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
-        n_intervals = Float64(duration) / Float64(dt)
-        isapprox(n_intervals, round(n_intervals); atol=1e-10, rtol=1e-10) ||
-            error("duration ($duration) must be an integer multiple of dt ($dt)")
+        mod(duration, dt) > 1e-10 * dt && error("duration ($duration) must be an integer multiple of dt ($dt)")
         CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
         max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
         if !isnothing(n_loop)

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -1,0 +1,124 @@
+"""
+    AbstractSolver
+
+Abstract supertype for all solver strategies.
+
+Concrete subtypes:
+- [`SteadyStateSolver`](@ref): solves each time step independently as a steady-state problem
+- [`TimeDependentSolver`](@ref): time-stepping with a Crank-Nicolson scheme
+
+The solver type controls both the numerical scheme used at each energy step and
+how time parameters (if any) are resolved into a time grid.
+"""
+abstract type AbstractSolver end
+
+"""
+    SteadyStateSolver()
+    SteadyStateSolver(t_total, dt)
+
+Solve each time step independently as a steady-state (time-independent) transport problem.
+
+When called **without arguments**, a single steady-state solve is performed — no time grid
+is created and the input flux must use [`ConstantModulation`](@ref).
+
+When called **with `t_total` and `dt`**, a [`UniformTimeGrid`](@ref) is built and each
+point is solved independently. This enables, e.g., a flickering input where each time step
+is solved in steady-state.
+
+# Examples
+```julia
+# Single-step steady-state
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+
+# Multi-step steady-state (each time point solved independently)
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.5, 0.01))
+```
+"""
+struct SteadyStateSolver <: AbstractSolver
+    t_total::Union{Nothing, Float64}
+    dt::Union{Nothing, Float64}
+
+    SteadyStateSolver() = new(nothing, nothing)
+
+    function SteadyStateSolver(t_total, dt)
+        t_total > 0 || error("t_total must be positive, got $t_total")
+        dt > 0 || error("dt must be positive, got $dt")
+        dt <= t_total || error("dt ($dt) must be ≤ t_total ($t_total)")
+        return new(Float64(t_total), Float64(dt))
+    end
+end
+
+"""
+    is_multi_step(solver::SteadyStateSolver)
+
+Return `true` if the solver is configured for multi-step steady-state.
+"""
+is_multi_step(solver::SteadyStateSolver) = !isnothing(solver.t_total)
+
+"""
+    TimeDependentSolver(t_total, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+
+Solve the transport equation in a time-dependent manner with a Crank-Nicolson scheme.
+
+# Arguments
+- `t_total`: total simulation time (s)
+- `dt`: time step for saving data (s). The internal time step may be finer to satisfy
+  the CFL condition.
+
+# Keyword Arguments
+- `CFL_number = 64`: CFL stability factor. Crank-Nicolson is unconditionally stable,
+  so large values are acceptable (it will affects the accuracy though).
+- `max_memory_gb = 8.0`: memory budget (GB) used to auto-split the simulation into loops.
+- `n_loop = nothing`: manually specify the number of loops. Overrides `max_memory_gb`.
+
+# Examples
+```julia
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+```
+"""
+struct TimeDependentSolver <: AbstractSolver
+    t_total::Float64
+    dt::Float64
+    CFL_number::Float64
+    max_memory_gb::Float64
+    n_loop::Union{Nothing, Int}
+end
+
+function TimeDependentSolver(t_total, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+    t_total > 0 || error("t_total must be positive, got $t_total")
+    dt > 0 || error("dt must be positive, got $dt")
+    dt <= t_total || error("dt ($dt) must be ≤ t_total ($t_total)")
+    CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
+    max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
+    if !isnothing(n_loop)
+        n_loop > 0 || error("n_loop must be positive, got $n_loop")
+    end
+    return TimeDependentSolver(Float64(t_total), Float64(dt), Float64(CFL_number),
+                               Float64(max_memory_gb), n_loop)
+end
+
+function Base.show(io::IO, ::SteadyStateSolver)
+    print(io, "SteadyStateSolver()")
+end
+function Base.show(io::IO, ::MIME"text/plain", s::SteadyStateSolver)
+    if is_multi_step(s)
+        println(io, "SteadyStateSolver (multi-step):")
+        println(io, "├── t_total: ", s.t_total, " s")
+        print(io,   "└── dt:      ", s.dt, " s")
+    else
+        print(io, "SteadyStateSolver (single-step)")
+    end
+end
+
+function Base.show(io::IO, s::TimeDependentSolver)
+    print(io, "TimeDependentSolver(t_total=$(s.t_total), dt=$(s.dt))")
+end
+function Base.show(io::IO, ::MIME"text/plain", s::TimeDependentSolver)
+    println(io, "TimeDependentSolver:")
+    println(io, "├── t_total:      ", s.t_total, " s")
+    println(io, "├── dt:           ", s.dt, " s")
+    println(io, "├── CFL number:   ", s.CFL_number)
+    println(io, "├── Memory limit: ", s.max_memory_gb, " GB")
+    print(io,   "└── n_loop:       ", isnothing(s.n_loop) ? "auto" : s.n_loop)
+end

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -48,7 +48,8 @@ function SteadyStateMode(; duration=nothing, dt=nothing)
     duration > 0 || error("duration must be positive, got $duration")
     dt > 0 || error("dt must be positive, got $dt")
     dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
-    mod(duration, dt) > 1e-10 * dt && error("duration ($duration) must be an integer multiple of dt ($dt)")
+    isapprox(round(duration / dt) * dt, duration; rtol=1e-10) ||
+        error("duration ($duration) must be an integer multiple of dt ($dt)")
     return SteadyStateMode(Float64(duration), Float64(dt))
 end
 
@@ -99,7 +100,8 @@ struct TimeDependentMode <: AbstractMode
         duration > 0 || error("duration must be positive, got $duration")
         dt > 0 || error("dt must be positive, got $dt")
         dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
-        mod(duration, dt) > 1e-10 * dt && error("duration ($duration) must be an integer multiple of dt ($dt)")
+        isapprox(round(duration / dt) * dt, duration; rtol=1e-10) ||
+            error("duration ($duration) must be an integer multiple of dt ($dt)")
         CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
         max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
         if !isnothing(n_loop)

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -78,7 +78,7 @@ Solve the transport equation in a time-dependent manner with a Crank-Nicolson sc
 - `dt`: time step for saving data (s). The internal time step may be finer to satisfy
   the CFL condition.
 - `CFL_number = 64`: CFL stability factor. Crank-Nicolson is unconditionally stable,
-  so large values are acceptable (it will affects the accuracy though).
+  so large values are acceptable (it will affect the accuracy though).
 - `max_memory_gb = 8.0`: memory budget (GB) used to auto-split the simulation into loops.
 - `n_loop = nothing`: manually specify the number of loops. Overrides `max_memory_gb`.
 

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -1,67 +1,75 @@
 """
-    AbstractSolver
+    AbstractMode
 
-Abstract supertype for all solver strategies.
+Abstract supertype for simulation modes.
 
 Concrete subtypes:
-- [`SteadyStateSolver`](@ref): solves each time step independently as a steady-state problem
-- [`TimeDependentSolver`](@ref): time-stepping with a Crank-Nicolson scheme
+- [`SteadyStateMode`](@ref): solves each time step independently as a steady-state problem
+- [`TimeDependentMode`](@ref): time-stepping with a Crank-Nicolson scheme
 
-The solver type controls both the numerical scheme used at each energy step and
-how time parameters (if any) are resolved into a time grid.
+The mode controls both the numerical scheme used at each energy step and how
+time parameters (if any) are resolved into an internal time configuration.
 """
-abstract type AbstractSolver end
+abstract type AbstractMode end
 
 """
-    SteadyStateSolver()
-    SteadyStateSolver(t_total, dt)
+    SteadyStateMode()
+    SteadyStateMode(duration, dt)
 
 Solve each time step independently as a steady-state (time-independent) transport problem.
 
 When called **without arguments**, a single steady-state solve is performed — no time grid
 is created and the input flux must use [`ConstantModulation`](@ref).
 
-When called **with `t_total` and `dt`**, a [`UniformTimeGrid`](@ref) is built and each
+When called **with `duration` and `dt`**, a [`UniformTimeGrid`](@ref) is built and each
 point is solved independently. This enables, e.g., a flickering input where each time step
 is solved in steady-state.
 
 # Examples
 ```julia
 # Single-step steady-state
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
 # Multi-step steady-state (each time point solved independently)
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.5, 0.01))
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.5, 0.01))
 ```
 """
-struct SteadyStateSolver <: AbstractSolver
-    t_total::Union{Nothing, Float64}
+struct SteadyStateMode <: AbstractMode
+    duration::Union{Nothing, Float64}
     dt::Union{Nothing, Float64}
 
-    SteadyStateSolver() = new(nothing, nothing)
+    SteadyStateMode() = new(nothing, nothing)
 
-    function SteadyStateSolver(t_total, dt)
-        t_total > 0 || error("t_total must be positive, got $t_total")
+    function SteadyStateMode(duration, dt)
+        duration > 0 || error("duration must be positive, got $duration")
         dt > 0 || error("dt must be positive, got $dt")
-        dt <= t_total || error("dt ($dt) must be ≤ t_total ($t_total)")
-        return new(Float64(t_total), Float64(dt))
+        dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
+        return new(Float64(duration), Float64(dt))
     end
 end
 
 """
-    is_multi_step(solver::SteadyStateSolver)
+    is_multi_step(mode::SteadyStateMode)
 
-Return `true` if the solver is configured for multi-step steady-state.
+Return `true` if the mode is configured for multi-step steady-state.
 """
-is_multi_step(solver::SteadyStateSolver) = !isnothing(solver.t_total)
+is_multi_step(mode::SteadyStateMode) = !isnothing(mode.duration)
 
 """
-    TimeDependentSolver(t_total, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+    SteadyState()
+    SteadyState(duration, dt)
+
+Convenience alias for [`SteadyStateMode`](@ref).
+"""
+const SteadyState = SteadyStateMode
+
+"""
+    TimeDependentMode(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
 
 Solve the transport equation in a time-dependent manner with a Crank-Nicolson scheme.
 
 # Arguments
-- `t_total`: total simulation time (s)
+- `duration`: total simulation time (s)
 - `dt`: time step for saving data (s). The internal time step may be finer to satisfy
   the CFL condition.
 
@@ -74,49 +82,63 @@ Solve the transport equation in a time-dependent manner with a Crank-Nicolson sc
 # Examples
 ```julia
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
 ```
 """
-struct TimeDependentSolver <: AbstractSolver
-    t_total::Float64
+struct TimeDependentMode <: AbstractMode
+    duration::Float64
     dt::Float64
     CFL_number::Float64
     max_memory_gb::Float64
     n_loop::Union{Nothing, Int}
 end
 
-function TimeDependentSolver(t_total, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
-    t_total > 0 || error("t_total must be positive, got $t_total")
+function TimeDependentMode(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+    duration > 0 || error("duration must be positive, got $duration")
     dt > 0 || error("dt must be positive, got $dt")
-    dt <= t_total || error("dt ($dt) must be ≤ t_total ($t_total)")
+    dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
+    n_intervals = Float64(duration) / Float64(dt)
+    isapprox(n_intervals, round(n_intervals); atol=1e-10, rtol=1e-10) ||
+        error("duration ($duration) must be an integer multiple of dt ($dt)")
     CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
     max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
     if !isnothing(n_loop)
         n_loop > 0 || error("n_loop must be positive, got $n_loop")
     end
-    return TimeDependentSolver(Float64(t_total), Float64(dt), Float64(CFL_number),
-                               Float64(max_memory_gb), n_loop)
+    return TimeDependentMode(Float64(duration), Float64(dt), Float64(CFL_number),
+                             Float64(max_memory_gb), n_loop)
 end
 
-function Base.show(io::IO, ::SteadyStateSolver)
-    print(io, "SteadyStateSolver()")
-end
-function Base.show(io::IO, ::MIME"text/plain", s::SteadyStateSolver)
+"""
+    TimeDependent(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+
+Convenience alias for [`TimeDependentMode`](@ref).
+"""
+const TimeDependent = TimeDependentMode
+
+function Base.show(io::IO, s::SteadyStateMode)
     if is_multi_step(s)
-        println(io, "SteadyStateSolver (multi-step):")
-        println(io, "├── t_total: ", s.t_total, " s")
+        print(io, "SteadyStateMode(duration=$(s.duration), dt=$(s.dt))")
+    else
+        print(io, "SteadyStateMode()")
+    end
+end
+function Base.show(io::IO, ::MIME"text/plain", s::SteadyStateMode)
+    if is_multi_step(s)
+        println(io, "SteadyStateMode (multi-step):")
+        println(io, "├── duration: ", s.duration, " s")
         print(io,   "└── dt:      ", s.dt, " s")
     else
-        print(io, "SteadyStateSolver (single-step)")
+        print(io, "SteadyStateMode (single-step)")
     end
 end
 
-function Base.show(io::IO, s::TimeDependentSolver)
-    print(io, "TimeDependentSolver(t_total=$(s.t_total), dt=$(s.dt))")
+function Base.show(io::IO, s::TimeDependentMode)
+    print(io, "TimeDependentMode(duration=$(s.duration), dt=$(s.dt))")
 end
-function Base.show(io::IO, ::MIME"text/plain", s::TimeDependentSolver)
-    println(io, "TimeDependentSolver:")
-    println(io, "├── t_total:      ", s.t_total, " s")
+function Base.show(io::IO, ::MIME"text/plain", s::TimeDependentMode)
+    println(io, "TimeDependentMode:")
+    println(io, "├── duration:     ", s.duration, " s")
     println(io, "├── dt:           ", s.dt, " s")
     println(io, "├── CFL number:   ", s.CFL_number)
     println(io, "├── Memory limit: ", s.max_memory_gb, " GB")

--- a/src/solvers/types.jl
+++ b/src/solvers/types.jl
@@ -14,7 +14,7 @@ abstract type AbstractMode end
 
 """
     SteadyStateMode()
-    SteadyStateMode(duration, dt)
+    SteadyStateMode(; duration, dt)
 
 Solve each time step independently as a steady-state (time-independent) transport problem.
 
@@ -31,7 +31,7 @@ is solved in steady-state.
 sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
 # Multi-step steady-state (each time point solved independently)
-sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.5, 0.01))
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration=0.5, dt=0.01))
 ```
 """
 struct SteadyStateMode <: AbstractMode
@@ -40,7 +40,7 @@ struct SteadyStateMode <: AbstractMode
 
     SteadyStateMode() = new(nothing, nothing)
 
-    function SteadyStateMode(duration, dt)
+    function SteadyStateMode(; duration, dt)
         duration > 0 || error("duration must be positive, got $duration")
         dt > 0 || error("dt must be positive, got $dt")
         dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
@@ -57,23 +57,21 @@ is_multi_step(mode::SteadyStateMode) = !isnothing(mode.duration)
 
 """
     SteadyState()
-    SteadyState(duration, dt)
+    SteadyState(; duration, dt)
 
 Convenience alias for [`SteadyStateMode`](@ref).
 """
 const SteadyState = SteadyStateMode
 
 """
-    TimeDependentMode(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+    TimeDependentMode(; duration, dt, CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
 
 Solve the transport equation in a time-dependent manner with a Crank-Nicolson scheme.
 
-# Arguments
+# Keyword Arguments
 - `duration`: total simulation time (s)
 - `dt`: time step for saving data (s). The internal time step may be finer to satisfy
   the CFL condition.
-
-# Keyword Arguments
 - `CFL_number = 64`: CFL stability factor. Crank-Nicolson is unconditionally stable,
   so large values are acceptable (it will affects the accuracy though).
 - `max_memory_gb = 8.0`: memory budget (GB) used to auto-split the simulation into loops.
@@ -82,7 +80,7 @@ Solve the transport equation in a time-dependent manner with a Crank-Nicolson sc
 # Examples
 ```julia
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(0.5, 0.001; CFL_number=128))
+                       mode=TimeDependentMode(duration=0.5, dt=0.001, CFL_number=128))
 ```
 """
 struct TimeDependentMode <: AbstractMode
@@ -91,26 +89,27 @@ struct TimeDependentMode <: AbstractMode
     CFL_number::Float64
     max_memory_gb::Float64
     n_loop::Union{Nothing, Int}
-end
 
-function TimeDependentMode(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
-    duration > 0 || error("duration must be positive, got $duration")
-    dt > 0 || error("dt must be positive, got $dt")
-    dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
-    n_intervals = Float64(duration) / Float64(dt)
-    isapprox(n_intervals, round(n_intervals); atol=1e-10, rtol=1e-10) ||
-        error("duration ($duration) must be an integer multiple of dt ($dt)")
-    CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
-    max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
-    if !isnothing(n_loop)
-        n_loop > 0 || error("n_loop must be positive, got $n_loop")
+    function TimeDependentMode(; duration, dt, CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+        # A bunch of input validation to fail early if the user config is invalid
+        duration > 0 || error("duration must be positive, got $duration")
+        dt > 0 || error("dt must be positive, got $dt")
+        dt <= duration || error("dt ($dt) must be ≤ duration ($duration)")
+        n_intervals = Float64(duration) / Float64(dt)
+        isapprox(n_intervals, round(n_intervals); atol=1e-10, rtol=1e-10) ||
+            error("duration ($duration) must be an integer multiple of dt ($dt)")
+        CFL_number > 0 || error("CFL_number must be positive, got $CFL_number")
+        max_memory_gb > 0 || error("max_memory_gb must be positive, got $max_memory_gb")
+        if !isnothing(n_loop)
+            n_loop > 0 || error("n_loop must be positive, got $n_loop")
+        end
+        return new(Float64(duration), Float64(dt), Float64(CFL_number),
+                   Float64(max_memory_gb), n_loop)
     end
-    return TimeDependentMode(Float64(duration), Float64(dt), Float64(CFL_number),
-                             Float64(max_memory_gb), n_loop)
 end
 
 """
-    TimeDependent(duration, dt; CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
+    TimeDependent(; duration, dt, CFL_number=64, max_memory_gb=8.0, n_loop=nothing)
 
 Convenience alias for [`TimeDependentMode`](@ref).
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -103,21 +103,8 @@ import LibGit2
 import Pkg
 function save_parameters(sim::AuroraSimulation)
     model = sim.model
-    if isnothing(sim.time)
-        t_total = nothing
-        dt = nothing
-        dt_resolved = nothing
-        t = 1:1:1
-        n_loop = 1
-        CFL_number = 0.0
-    else
-        t_total = sim.time.t_total
-        dt = sim.time.dt_requested
-        dt_resolved = sim.time.dt_resolved
-        t = sim.time.t
-        n_loop = sim.time.n_loop
-        CFL_number = sim.time.CFL_number
-    end
+    solver = sim.solver
+
 	savefile = joinpath(sim.savedir, "parameters.txt")
     commit_hash = if isdir(joinpath(pkgdir(AURORA), ".git"))
         LibGit2.head(pkgdir(AURORA))
@@ -131,18 +118,34 @@ function save_parameters(sim::AuroraSimulation)
         write(f, "E_max = $(model.energy_grid.E_max) \n")
         write(f, "B_angle_to_zenith = $(model.B_angle_to_zenith) \n")
         write(f, "\n")
-        write(f, "t_total = $t_total \n")
-        write(f, "dt = $dt \n")
-        write(f, "dt_resolved = $dt_resolved \n")
-        write(f, "t = $t \n")
-        write(f, "n_loop = $n_loop \n")
-        write(f, "\n")
-        write(f, "CFL_number = $CFL_number")
+        write(f, "solver = $solver \n")
+        _write_time_params(f, sim)
         write(f, "\n")
         write(f, "flux = $(sim.flux) \n")
         write(f, "\n")
         write(f, "commit_hash = $commit_hash \n")
         write(f, "version_AURORA = $version_AURORA")
+    end
+end
+
+function _write_time_params(f::IO, sim::AuroraSimulation)
+    if sim.time isa RefinedTimeGrid
+        time = sim.time
+        write(f, "t_total = $(time.t_total) \n")
+        write(f, "dt = $(time.dt_requested) \n")
+        write(f, "dt_resolved = $(time.dt_resolved) \n")
+        write(f, "t = $(time.t) \n")
+        write(f, "n_loop = $(time.n_loop) \n")
+        write(f, "CFL_factor = $(time.CFL_factor) \n")
+    elseif sim.time isa UniformTimeGrid
+        time = sim.time
+        write(f, "t_total = $(time.t_total) \n")
+        write(f, "dt = $(time.dt) \n")
+        write(f, "n_steps = $(time.n_steps) \n")
+        write(f, "t = $(time.t) \n")
+    else
+        write(f, "t_total = nothing \n")
+        write(f, "dt = nothing \n")
     end
 end
 
@@ -192,6 +195,9 @@ function save_results(sim::AuroraSimulation, Ie_save, t, I0, i, CFL_factor)
     # Reduce t_run to match the t_sampling
     t_run = t_run[1:CFL_factor:end]
 
+    # Solver type tag for downstream analysis
+    solver_type = sim.solver isa SteadyStateSolver ? "steady_state" : "time_dependent"
+
     savefile = joinpath(sim.savedir, (@sprintf "IeFlickering-%02d.mat" i))
 	file = matopen(savefile, "w")
 		write(file, "Ie_ztE", Ie_save)
@@ -202,6 +208,7 @@ function save_results(sim::AuroraSimulation, Ie_save, t, I0, i, CFL_factor)
 		write(file, "mu_lims", collect(μ_lims))
 		write(file, "h_atm", z)
 		write(file, "I0", I0)
+        write(file, "solver_type", solver_type)
 		write(file, "mu_scatterings", Dict(
 			"P_scatter" => scattering.P_scatter,
             "BeamWeight_relative" => scattering.Ω_subbeam_relative,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -103,7 +103,7 @@ import LibGit2
 import Pkg
 function save_parameters(sim::AuroraSimulation)
     model = sim.model
-    solver = sim.solver
+    mode = sim.mode
 
 	savefile = joinpath(sim.savedir, "parameters.txt")
     commit_hash = if isdir(joinpath(pkgdir(AURORA), ".git"))
@@ -118,7 +118,7 @@ function save_parameters(sim::AuroraSimulation)
         write(f, "E_max = $(model.energy_grid.E_max) \n")
         write(f, "B_angle_to_zenith = $(model.B_angle_to_zenith) \n")
         write(f, "\n")
-        write(f, "solver = $solver \n")
+        write(f, "mode = $mode \n")
         _write_time_params(f, sim)
         write(f, "\n")
         write(f, "flux = $(sim.flux) \n")
@@ -128,25 +128,25 @@ function save_parameters(sim::AuroraSimulation)
     end
 end
 
-function _write_time_params(f::IO, sim::AuroraSimulation)
-    if sim.time isa RefinedTimeGrid
-        time = sim.time
-        write(f, "t_total = $(time.t_total) \n")
-        write(f, "dt = $(time.dt_requested) \n")
-        write(f, "dt_resolved = $(time.dt_resolved) \n")
-        write(f, "t = $(time.t) \n")
-        write(f, "n_loop = $(time.n_loop) \n")
-        write(f, "CFL_factor = $(time.CFL_factor) \n")
-    elseif sim.time isa UniformTimeGrid
-        time = sim.time
-        write(f, "t_total = $(time.t_total) \n")
-        write(f, "dt = $(time.dt) \n")
-        write(f, "n_steps = $(time.n_steps) \n")
-        write(f, "t = $(time.t) \n")
-    else
-        write(f, "t_total = nothing \n")
-        write(f, "dt = nothing \n")
-    end
+_write_time_params(f::IO, sim::AuroraSimulation) = _write_time_params(f, sim.time)
+
+function _write_time_params(f::IO, time::RefinedTimeGrid)
+    write(f, "duration = $(time.duration) \n")
+    write(f, "dt = $(time.dt_requested) \n")
+    write(f, "dt_resolved = $(time.dt_resolved) \n")
+    write(f, "t = $(time.t) \n")
+    write(f, "n_loop = $(time.n_loop) \n")
+    write(f, "CFL_factor = $(time.CFL_factor) \n")
+end
+function _write_time_params(f::IO, time::UniformTimeGrid)
+    write(f, "duration = $(time.duration) \n")
+    write(f, "dt = $(time.dt) \n")
+    write(f, "n_steps = $(time.n_steps) \n")
+    write(f, "t = $(time.t) \n")
+end
+function _write_time_params(f::IO, ::SingleStepConfig)
+    write(f, "duration = nothing \n")
+    write(f, "dt = nothing \n")
 end
 
 
@@ -181,6 +181,12 @@ function save_Ie_top(sim::AuroraSimulation, Ie_top, t)
     close(file)
 end
 
+_mode_type_tag(::RefinedTimeGrid)  = "time_dependent"
+_mode_type_tag(::UniformTimeGrid)  = "steady_state_multi_step"
+_mode_type_tag(::SingleStepConfig) = "steady_state_single_step"
+
+_solver_type_tag(::TimeDependentMode) = "time_dependent"
+_solver_type_tag(::SteadyStateMode)   = "steady_state"
 
 using MAT: matopen
 using Printf: @sprintf
@@ -195,8 +201,9 @@ function save_results(sim::AuroraSimulation, Ie_save, t, I0, i, CFL_factor)
     # Reduce t_run to match the t_sampling
     t_run = t_run[1:CFL_factor:end]
 
-    # Solver type tag for downstream analysis
-    solver_type = sim.solver isa SteadyStateSolver ? "steady_state" : "time_dependent"
+    # Mode type tags for downstream analysis
+    mode_type = _mode_type_tag(sim.time)
+    solver_type = _solver_type_tag(sim.mode)
 
     savefile = joinpath(sim.savedir, (@sprintf "IeFlickering-%02d.mat" i))
 	file = matopen(savefile, "w")
@@ -209,6 +216,7 @@ function save_results(sim::AuroraSimulation, Ie_save, t, I0, i, CFL_factor)
 		write(file, "h_atm", z)
 		write(file, "I0", I0)
         write(file, "solver_type", solver_type)
+        write(file, "mode_type", mode_type)
 		write(file, "mu_scatterings", Dict(
 			"P_scatter" => scattering.P_scatter,
             "BeamWeight_relative" => scattering.Ω_subbeam_relative,

--- a/test/analysis/test_fluxes.jl
+++ b/test/analysis/test_fluxes.jl
@@ -11,9 +11,6 @@
         θ_lims = 180:-90:0  # 2 beams: beam 1 down (μ<0), beam 2 up (μ>0)
         E_max = 100
         B_angle_to_zenith = 13
-        duration = 0.1
-        dt = 0.01
-        CFL_number = 128
 
         model = AuroraModel(altitude_lims, θ_lims, E_max,
                             find_msis_file(), find_iri_file(),
@@ -21,8 +18,8 @@
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), ConstantModulation();
                          beams=1, z_source=500.0)
         sim = AuroraSimulation(model, flux, savedir;
-                               mode=TimeDependentMode(duration, dt;
-                                                          CFL_number, n_loop=1))
+                               mode=TimeDependentMode(duration = 0.1, dt = 0.01,
+                                                      CFL_number = 128, n_loop = 1))
         run!(sim)
     end
 

--- a/test/analysis/test_fluxes.jl
+++ b/test/analysis/test_fluxes.jl
@@ -20,8 +20,9 @@
                             B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), ConstantModulation();
                          beams=1, z_source=500.0)
-        sim = AuroraSimulation(model, flux, t_total, dt, savedir;
-                               CFL_number, n_loop=1)
+        sim = AuroraSimulation(model, flux, savedir;
+                               solver=TimeDependentSolver(t_total, dt;
+                                                          CFL_number, n_loop=1))
         run!(sim)
     end
 

--- a/test/analysis/test_fluxes.jl
+++ b/test/analysis/test_fluxes.jl
@@ -11,7 +11,7 @@
         θ_lims = 180:-90:0  # 2 beams: beam 1 down (μ<0), beam 2 up (μ>0)
         E_max = 100
         B_angle_to_zenith = 13
-        t_total = 0.1
+        duration = 0.1
         dt = 0.01
         CFL_number = 128
 
@@ -21,7 +21,7 @@
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), ConstantModulation();
                          beams=1, z_source=500.0)
         sim = AuroraSimulation(model, flux, savedir;
-                               solver=TimeDependentSolver(t_total, dt;
+                               mode=TimeDependentMode(duration, dt;
                                                           CFL_number, n_loop=1))
         run!(sim)
     end

--- a/test/ext/test_plotting.jl
+++ b/test/ext/test_plotting.jl
@@ -71,7 +71,7 @@
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
         @test plot_input(sim) isa Figure
     end
@@ -113,7 +113,7 @@
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.04, 0.01))
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.04, 0.01))
         @test plot_input(sim) isa Figure
     end
 

--- a/test/ext/test_plotting.jl
+++ b/test/ext/test_plotting.jl
@@ -113,7 +113,7 @@
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(0.04, 0.01))
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration=0.04, dt=0.01))
         @test plot_input(sim) isa Figure
     end
 

--- a/test/ext/test_plotting.jl
+++ b/test/ext/test_plotting.jl
@@ -61,20 +61,60 @@
     end
 
     @testset "plot_input(sim) smoke" begin
-        mktempdir() do savedir
-            altitude_lims = [100, 200]
-            θ_lims = 180:-45:0
-            E_max = 100
-            B_angle_to_zenith = 13
-            msis_file = find_msis_file()
-            iri_file = find_iri_file()
+        altitude_lims = [100, 200]
+        θ_lims = 180:-45:0
+        E_max = 100
+        B_angle_to_zenith = 13
+        msis_file = find_msis_file()
+        iri_file = find_iri_file()
+        savedir = "fake_dir"  # won't be used since we're not running the sim
 
-            model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
-            flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0); beams = 1:2)
-            sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+        model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+        flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0); beams = 1:2)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
 
-            @test plot_input(sim) isa Figure
-        end
+        @test plot_input(sim) isa Figure
+    end
+
+    @testset "multi-step SS smoke" begin
+        vol_ms = load_volume_excitation(SharedSimResults.ms_ss_dir)
+        col_ms = load_column_excitation(SharedSimResults.ms_ss_dir)
+        inp_ms = load_input(SharedSimResults.ms_ss_dir)
+
+        # plot_excitation! heatmap over time
+        fig1 = Figure()
+        ax1 = Axis(fig1[1, 1])
+        @test plot_excitation!(ax1, vol_ms) isa Makie.Heatmap
+
+        # plot_excitation! single time slice
+        fig2 = Figure()
+        ax2 = Axis(fig2[1, 1]; xscale = log10)
+        mid_t = cld(length(vol_ms.t), 2)
+        @test plot_excitation!(ax2, vol_ms; time_index = mid_t) isa Makie.Lines
+
+        # plot_column_excitation!
+        fig3 = Figure()
+        ax3 = Axis(fig3[1, 1]; yscale = log10)
+        @test plot_column_excitation!(ax3, col_ms) isa Vector{Makie.Lines}
+
+        # plot_input! from loaded data
+        fig4 = Figure()
+        ax4 = Axis(fig4[1, 1]; yscale = log10)
+        @test plot_input!(ax4, inp_ms; beams = 1) isa Makie.Heatmap
+
+        # plot_input from sim object
+        altitude_lims = [100, 200]
+        θ_lims = 180:-45:0
+        E_max = 100
+        B_angle_to_zenith = 13
+        msis_file = find_msis_file()
+        iri_file = find_iri_file()
+        savedir = "fake_dir"  # won't be used since we're not running the sim
+
+        model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+        flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(0.04, 0.01))
+        @test plot_input(sim) isa Figure
     end
 
     # This testset will display figures when run on a personal machine, which is to be

--- a/test/ext/test_plotting.jl
+++ b/test/ext/test_plotting.jl
@@ -71,7 +71,7 @@
 
             model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
             flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0); beams = 1:2)
-            sim = AuroraSimulation(model, flux, savedir)
+            sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
 
             @test plot_input(sim) isa Figure
         end

--- a/test/input/test_input.jl
+++ b/test/input/test_input.jl
@@ -374,7 +374,7 @@ end
         # Define input flux
         flux = InputFlux(MaxwellianSpectrum(1e-3, 50); beams=1)
         # Run simulation
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
         run!(sim)
         @test true
     end
@@ -393,7 +393,7 @@ end
         # Define input flux
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
         # Run simulation
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
         run!(sim)
         @test true
     end
@@ -406,7 +406,7 @@ end
         θ_lims = 180:-45:0;             # (°) angle-limits for the electron beams
         E_max = 100;                    # (eV) upper limit to the energy grid
         B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
-        t_total = 0.1;                  # (s) total simulation time
+        duration = 0.1;                  # (s) total simulation time
         dt = 0.01;                      # (s) time step for saving data
         n_loop = 2;                     # number of loops to run
         CFL_number = 128;
@@ -418,7 +418,7 @@ end
                          beams=1:2, z_source=500.0)
         # Run simulation
         sim = AuroraSimulation(model, flux, savedir;
-                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop))
+                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop))
         run!(sim)
         @test true
     end
@@ -431,7 +431,7 @@ end
         θ_lims = 180:-45:0;             # (°) angle-limits for the electron beams
         E_max = 100;                    # (eV) upper limit to the energy grid
         B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
-        t_total = 0.1;                  # (s) total simulation time
+        duration = 0.1;                  # (s) total simulation time
         dt = 0.01;                      # (s) time step for saving data
         n_loop = 2;                     # number of loops to run
         CFL_number = 128;
@@ -443,7 +443,7 @@ end
                          beams=1, z_source=1000.0)
         # Run simulation
         sim = AuroraSimulation(model, flux, savedir;
-                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop))
+                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop))
         run!(sim)
         @test true
     end

--- a/test/input/test_input.jl
+++ b/test/input/test_input.jl
@@ -374,7 +374,7 @@ end
         # Define input flux
         flux = InputFlux(MaxwellianSpectrum(1e-3, 50); beams=1)
         # Run simulation
-        sim = AuroraSimulation(model, flux, savedir)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
         run!(sim)
         @test true
     end
@@ -393,7 +393,7 @@ end
         # Define input flux
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
         # Run simulation
-        sim = AuroraSimulation(model, flux, savedir)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
         run!(sim)
         @test true
     end
@@ -417,7 +417,8 @@ end
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), SmoothOnset(0.0, 0.05);
                          beams=1:2, z_source=500.0)
         # Run simulation
-        sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number, n_loop)
+        sim = AuroraSimulation(model, flux, savedir;
+                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop))
         run!(sim)
         @test true
     end
@@ -441,7 +442,8 @@ end
         flux = InputFlux(FlatSpectrum(1e-2; E_min=50.0), SinusoidalFlickering(5.0);
                          beams=1, z_source=1000.0)
         # Run simulation
-        sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number, n_loop)
+        sim = AuroraSimulation(model, flux, savedir;
+                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop))
         run!(sim)
         @test true
     end

--- a/test/input/test_input.jl
+++ b/test/input/test_input.jl
@@ -406,10 +406,6 @@ end
         θ_lims = 180:-45:0;             # (°) angle-limits for the electron beams
         E_max = 100;                    # (eV) upper limit to the energy grid
         B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
-        duration = 0.1;                  # (s) total simulation time
-        dt = 0.01;                      # (s) time step for saving data
-        n_loop = 2;                     # number of loops to run
-        CFL_number = 128;
         msis_file = find_msis_file();
         iri_file = find_iri_file();
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
@@ -418,7 +414,8 @@ end
                          beams=1:2, z_source=500.0)
         # Run simulation
         sim = AuroraSimulation(model, flux, savedir;
-                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop))
+                               mode=TimeDependentMode(duration = 0.1, dt = 0.01,
+                                                      CFL_number = 128, n_loop = 2))
         run!(sim)
         @test true
     end
@@ -431,10 +428,6 @@ end
         θ_lims = 180:-45:0;             # (°) angle-limits for the electron beams
         E_max = 100;                    # (eV) upper limit to the energy grid
         B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
-        duration = 0.1;                  # (s) total simulation time
-        dt = 0.01;                      # (s) time step for saving data
-        n_loop = 2;                     # number of loops to run
-        CFL_number = 128;
         msis_file = find_msis_file();
         iri_file = find_iri_file();
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
@@ -443,7 +436,8 @@ end
                          beams=1, z_source=1000.0)
         # Run simulation
         sim = AuroraSimulation(model, flux, savedir;
-                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop))
+                               mode=TimeDependentMode(duration = 0.1, dt = 0.01,
+                                                      CFL_number = 128, n_loop = 2))
         run!(sim)
         @test true
     end

--- a/test/regression/reference_results/control_script_copy.jl
+++ b/test/regression/reference_results/control_script_copy.jl
@@ -52,10 +52,6 @@ altitude_lims = [100, 400];     # (km) altitude limits of the ionosphere
 E_max = 500;                   # (eV) upper limit to the energy grid
 B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-duration = 0.2;                  # (s) total simulation time
-dt = 0.01;                      # (s) time step for saving data
-CFL_number = 128;
-
 msis_file = "test/regression/reference_results/msis_20051008-2200_70N-19E.txt"
 iri_file = "test/regression/reference_results/iri_20051008-2200_70N-19E.txt"
 
@@ -73,7 +69,8 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=100.0), SinusoidalFlickering(5.0);
 
 ## Run the simulation
 sim = AuroraSimulation(model, flux, savedir;
-                       mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
+                       mode=TimeDependentMode(duration = 0.2, dt = 0.01,
+                                              CFL_number = 128, n_loop = 2))
 run!(sim)
 
 ## Analyze the results

--- a/test/regression/reference_results/control_script_copy.jl
+++ b/test/regression/reference_results/control_script_copy.jl
@@ -25,7 +25,7 @@ savedir = make_savedir(root_savedir, name_savedir; behavior = "custom")
 flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
 ## Run the simulation
-sim = AuroraSimulation(model, flux, savedir)
+sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
 run!(sim)
 
 ## Analyze the results
@@ -72,7 +72,8 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=100.0), SinusoidalFlickering(5.0);
                  beams=1, z_source=1000.0)
 
 ## Run the simulation
-sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number, n_loop=2)
+sim = AuroraSimulation(model, flux, savedir;
+                       solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
 run!(sim)
 
 ## Analyze the results

--- a/test/regression/reference_results/control_script_copy.jl
+++ b/test/regression/reference_results/control_script_copy.jl
@@ -25,7 +25,7 @@ savedir = make_savedir(root_savedir, name_savedir; behavior = "custom")
 flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
 ## Run the simulation
-sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 run!(sim)
 
 ## Analyze the results
@@ -52,7 +52,7 @@ altitude_lims = [100, 400];     # (km) altitude limits of the ionosphere
 E_max = 500;                   # (eV) upper limit to the energy grid
 B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-t_total = 0.2;                  # (s) total simulation time
+duration = 0.2;                  # (s) total simulation time
 dt = 0.01;                      # (s) time step for saving data
 CFL_number = 128;
 
@@ -73,7 +73,7 @@ flux = InputFlux(FlatSpectrum(1e-2; E_min=100.0), SinusoidalFlickering(5.0);
 
 ## Run the simulation
 sim = AuroraSimulation(model, flux, savedir;
-                       solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
+                       mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
 run!(sim)
 
 ## Analyze the results

--- a/test/regression/test_regression.jl
+++ b/test/regression/test_regression.jl
@@ -20,7 +20,7 @@
     flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
     ## Run the simulation
-    sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+    sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
     run!(sim)
 
     ## Analyze the results
@@ -51,7 +51,7 @@ end
     E_max = 500;                   # (eV) upper limit to the energy grid
     B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-    t_total = 0.2
+    duration = 0.2
     dt = 0.01
     CFL_number = 128;
 
@@ -72,7 +72,7 @@ end
 
     ## Run the simulation
     sim = AuroraSimulation(model, flux, savedir;
-                           solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
+                           mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
     run!(sim)
 
     ## Analyze the results

--- a/test/regression/test_regression.jl
+++ b/test/regression/test_regression.jl
@@ -20,7 +20,7 @@
     flux = InputFlux(FlatSpectrum(1e-2; E_min=E_max - 100); beams=1:2)
 
     ## Run the simulation
-    sim = AuroraSimulation(model, flux, savedir)
+    sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
     run!(sim)
 
     ## Analyze the results
@@ -71,7 +71,8 @@ end
                      beams=1, z_source=1000.0)
 
     ## Run the simulation
-    sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number, n_loop = 2)
+    sim = AuroraSimulation(model, flux, savedir;
+                           solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
     run!(sim)
 
     ## Analyze the results

--- a/test/regression/test_regression.jl
+++ b/test/regression/test_regression.jl
@@ -51,10 +51,6 @@ end
     E_max = 500;                   # (eV) upper limit to the energy grid
     B_angle_to_zenith = 13;         # (°) angle between the B-field line and the zenith
 
-    duration = 0.2
-    dt = 0.01
-    CFL_number = 128;
-
     msis_file = joinpath(@__DIR__, "reference_results", "msis_20051008-2200_70N-19E.txt")
     iri_file = joinpath(@__DIR__, "reference_results", "iri_20051008-2200_70N-19E.txt")
 
@@ -72,7 +68,8 @@ end
 
     ## Run the simulation
     sim = AuroraSimulation(model, flux, savedir;
-                           mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
+                           mode=TimeDependentMode(duration = 0.2, dt = 0.01,
+                                                  CFL_number = 128, n_loop = 2))
     run!(sim)
 
     ## Analyze the results

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ using TestItems
     # --- Steady-state simulation ---
     ss_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, ss_dir)
+        sim = AuroraSimulation(model, flux, ss_dir; solver=SteadyStateSolver())
         run!(sim)
     end
     make_volume_excitation_file(ss_dir)
@@ -26,7 +26,8 @@ using TestItems
     # --- Time-dependent simulation (2 loops) ---
     td_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, 0.1, 0.01, td_dir; CFL_number = 128, n_loop = 2)
+        sim = AuroraSimulation(model, flux, td_dir;
+                               solver=TimeDependentSolver(0.1, 0.01; CFL_number=128, n_loop=2))
         run!(sim)
     end
     make_volume_excitation_file(td_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ using TestItems
     # --- Multi-step steady-state simulation ---
     ms_ss_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, ms_ss_dir; mode=SteadyStateMode(0.1, 0.01))
+        sim = AuroraSimulation(model, flux, ms_ss_dir; mode=SteadyStateMode(duration=0.1, dt=0.01))
         run!(sim)
     end
     make_volume_excitation_file(ms_ss_dir)
@@ -36,7 +36,8 @@ using TestItems
     td_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
         sim = AuroraSimulation(model, flux, td_dir;
-                               mode=TimeDependentMode(0.1, 0.01; CFL_number=128, n_loop=2))
+                               mode=TimeDependentMode(duration=0.1, dt=0.01,
+                                                      CFL_number=128, n_loop=2))
         run!(sim)
     end
     make_volume_excitation_file(td_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,15 @@ using TestItems
     make_volume_excitation_file(ss_dir)
     make_column_excitation_file(ss_dir)
 
+    # --- Multi-step steady-state simulation ---
+    ms_ss_dir = mktempdir(; cleanup = true)
+    let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
+        sim = AuroraSimulation(model, flux, ms_ss_dir; solver=SteadyStateSolver(0.1, 0.01))
+        run!(sim)
+    end
+    make_volume_excitation_file(ms_ss_dir)
+    make_column_excitation_file(ms_ss_dir)
+
     # --- Time-dependent simulation (2 loops) ---
     td_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ using TestItems
     # --- Steady-state simulation ---
     ss_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, ss_dir; solver=SteadyStateSolver())
+        sim = AuroraSimulation(model, flux, ss_dir; mode=SteadyStateMode())
         run!(sim)
     end
     make_volume_excitation_file(ss_dir)
@@ -26,7 +26,7 @@ using TestItems
     # --- Multi-step steady-state simulation ---
     ms_ss_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
-        sim = AuroraSimulation(model, flux, ms_ss_dir; solver=SteadyStateSolver(0.1, 0.01))
+        sim = AuroraSimulation(model, flux, ms_ss_dir; mode=SteadyStateMode(0.1, 0.01))
         run!(sim)
     end
     make_volume_excitation_file(ms_ss_dir)
@@ -36,7 +36,7 @@ using TestItems
     td_dir = mktempdir(; cleanup = true)
     let flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
         sim = AuroraSimulation(model, flux, td_dir;
-                               solver=TimeDependentSolver(0.1, 0.01; CFL_number=128, n_loop=2))
+                               mode=TimeDependentMode(0.1, 0.01; CFL_number=128, n_loop=2))
         run!(sim)
     end
     make_volume_excitation_file(td_dir)

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -56,14 +56,13 @@ end
         θ_lims = 180:-90:0
         E_max = 100
         B_angle_to_zenith = 13
-        duration = 0.04
-        dt = 0.01
+
         msis_file = find_msis_file()
         iri_file = find_iri_file()
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), SinusoidalFlickering(5.0); beams=1:2)
-        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration, dt))
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration = 0.04, dt = 0.01))
 
         run!(sim)
 
@@ -95,15 +94,14 @@ end
     end
 end
 
-@testitem "UniformTimeGrid divisibility check" begin
+@testitem "SteadyStateMode divisibility check" begin
     # duration not an integer multiple of dt → error
-    @test_throws ErrorException UniformTimeGrid(0.05, 0.02)
+    @test_throws ErrorException SteadyStateMode(duration=0.05, dt=0.02)
 
     # exact multiple → succeeds
-    grid = UniformTimeGrid(0.04, 0.01)
-    @test grid.n_steps == 5   # includes t=0 and t=duration (n_intervals + 1)
-    @test grid.duration == 0.04
-    @test grid.dt == 0.01
+    mode = SteadyStateMode(duration=0.04, dt=0.01)
+    @test mode.duration == 0.04
+    @test mode.dt == 0.01
 end
 
 @testitem "TimeDependentMode divisibility check" begin

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -4,7 +4,7 @@
         θ_lims = 180:-45:0
         E_max = 100
         B_angle_to_zenith = 13
-        t_total = 0.1
+        duration = 0.1
         dt = 0.01
         CFL_number = 128
         msis_file = find_msis_file()
@@ -15,7 +15,7 @@
                          beams=1:2, z_source=500.0)
 
         sim = AuroraSimulation(model, flux, savedir;
-                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
+                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
 
         @test sim.cache === nothing
         @test sim.time isa RefinedTimeGrid
@@ -40,7 +40,7 @@ end
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
         @test sim.cache === nothing
 
@@ -57,14 +57,14 @@ end
         θ_lims = 180:-90:0
         E_max = 100
         B_angle_to_zenith = 13
-        t_total = 0.04
+        duration = 0.04
         dt = 0.01
         msis_file = find_msis_file()
         iri_file = find_iri_file()
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), SinusoidalFlickering(5.0); beams=1:2)
-        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(t_total, dt))
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration, dt))
 
         run!(sim)
 
@@ -79,4 +79,56 @@ end
         # Ie_ztE time dimension must also match
         @test size(data["Ie_ztE"], 2) == length(expected_t)
     end
+end
+
+@testitem "SteadyStateMode() → SingleStepConfig" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 13)
+        flux  = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
+
+        sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
+
+        @test sim.time isa SingleStepConfig
+        @test sim.time.n_steps == 1
+        @test sim.time.t == 1:1
+    end
+end
+
+@testitem "UniformTimeGrid divisibility check" begin
+    # duration not an integer multiple of dt → error
+    @test_throws ErrorException UniformTimeGrid(0.05, 0.02)
+
+    # exact multiple → succeeds
+    grid = UniformTimeGrid(0.04, 0.01)
+    @test grid.n_steps == 5   # includes t=0 and t=duration (n_intervals + 1)
+    @test grid.duration == 0.04
+    @test grid.dt == 0.01
+end
+
+@testitem "TimeDependentMode divisibility check" begin
+    # duration not an integer multiple of dt → error
+    @test_throws ErrorException TimeDependentMode(0.05, 0.02; CFL_number=64)
+
+    # exact multiple → succeeds
+    mode = TimeDependentMode(0.04, 0.01; CFL_number=64)
+    @test mode.duration == 0.04
+    @test mode.dt == 0.01
+end
+
+@testitem "Mode aliases construct canonical types" begin
+    steady_state = SteadyState()
+    multi_step = SteadyState(0.04, 0.01)
+    time_dependent = TimeDependent(0.04, 0.01; CFL_number=64)
+
+    @test steady_state isa SteadyStateMode
+    @test multi_step isa SteadyStateMode
+    @test time_dependent isa TimeDependentMode
+
+    @test isnothing(steady_state.duration)
+    @test multi_step.duration == 0.04
+    @test multi_step.dt == 0.01
+    @test time_dependent.duration == 0.04
+    @test time_dependent.dt == 0.01
 end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -49,3 +49,34 @@ end
         @test sim.cache !== nothing
     end
 end
+
+@testitem "Multi-step SS: saved t_run matches time grid" begin
+    using MAT
+    mktempdir() do savedir
+        altitude_lims = [100, 200]
+        θ_lims = 180:-90:0
+        E_max = 100
+        B_angle_to_zenith = 13
+        t_total = 0.04
+        dt = 0.01
+        msis_file = find_msis_file()
+        iri_file = find_iri_file()
+
+        model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+        flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), SinusoidalFlickering(5.0); beams=1:2)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver(t_total, dt))
+
+        run!(sim)
+
+        data = matread(joinpath(savedir, "IeFlickering-01.mat"))
+        t_run = vec(data["t_run"])
+        expected_t = collect(sim.time.t)
+
+        # t_run must span the full time axis, not be a scalar 1
+        @test length(t_run) == length(expected_t)
+        @test t_run ≈ expected_t
+
+        # Ie_ztE time dimension must also match
+        @test size(data["Ie_ztE"], 2) == length(expected_t)
+    end
+end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -4,9 +4,7 @@
         θ_lims = 180:-45:0
         E_max = 100
         B_angle_to_zenith = 13
-        duration = 0.1
-        dt = 0.01
-        CFL_number = 128
+
         msis_file = find_msis_file()
         iri_file = find_iri_file()
 
@@ -15,7 +13,8 @@
                          beams=1:2, z_source=500.0)
 
         sim = AuroraSimulation(model, flux, savedir;
-                               mode=TimeDependentMode(duration, dt; CFL_number, n_loop=2))
+                               mode=TimeDependentMode(duration = 0.1, dt = 0.01,
+                                                      CFL_number = 128, n_loop = 2))
 
         @test sim.cache === nothing
         @test sim.time isa RefinedTimeGrid
@@ -109,18 +108,18 @@ end
 
 @testitem "TimeDependentMode divisibility check" begin
     # duration not an integer multiple of dt → error
-    @test_throws ErrorException TimeDependentMode(0.05, 0.02; CFL_number=64)
+    @test_throws ErrorException TimeDependentMode(duration=0.05, dt=0.02, CFL_number=64)
 
     # exact multiple → succeeds
-    mode = TimeDependentMode(0.04, 0.01; CFL_number=64)
+    mode = TimeDependentMode(duration=0.04, dt=0.01, CFL_number=64)
     @test mode.duration == 0.04
     @test mode.dt == 0.01
 end
 
 @testitem "Mode aliases construct canonical types" begin
     steady_state = SteadyState()
-    multi_step = SteadyState(0.04, 0.01)
-    time_dependent = TimeDependent(0.04, 0.01; CFL_number=64)
+    multi_step = SteadyState(duration=0.04, dt=0.01)
+    time_dependent = TimeDependent(duration=0.04, dt=0.01, CFL_number=64)
 
     @test steady_state isa SteadyStateMode
     @test multi_step isa SteadyStateMode

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -14,10 +14,11 @@
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0), SmoothOnset(0.0, 0.05);
                          beams=1:2, z_source=500.0)
 
-        sim = AuroraSimulation(model, flux, t_total, dt, savedir; CFL_number, n_loop=2)
+        sim = AuroraSimulation(model, flux, savedir;
+                               solver=TimeDependentSolver(t_total, dt; CFL_number, n_loop=2))
 
         @test sim.cache === nothing
-        @test sim.time isa ResolvedTimeGrid
+        @test sim.time isa RefinedTimeGrid
         @test sim.time.dt_resolved <= sim.time.dt_requested
 
         initialize!(sim)
@@ -39,7 +40,7 @@ end
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
-        sim = AuroraSimulation(model, flux, savedir)
+        sim = AuroraSimulation(model, flux, savedir; solver=SteadyStateSolver())
 
         @test sim.cache === nothing
 


### PR DESCRIPTION
Introduce the `AbstractMode` type to choose what version of the code (steady-state or time-dependent) to run.

This introduces the possibility to run multi-step steady-state (where each step is solved independently). Optimizations (should be easy to multi-thread/distribute) are left for future work.

**Breaking**
`AuroraSimulation(model, flux, 0.5, 0.01, savedir)` → `AuroraSimulation(model, flux, savedir; mode=TimeDependentMode(duration=0.5, dt=0.01))`, or even (thanks to some aliases) just
`AuroraSimulation(model, flux, savedir; mode=TimeDependent(duration=0.5, dt=0.01))` .

More information in the documentation.


## TODO
- [x] add an entry in CHANGELOG.md
