### PR TITLE
Modular species + two-phase model construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-- **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125) [#126](https://github.com/egavazzi/AURORA.jl/pull/126)
-  - Simulations are now set up by building an `AuroraModel`, creating an `InputFlux`, constructing an `AuroraSimulation`, and calling `run!(sim)`. The old `calculate_e_transport()` and `calculate_e_transport_steady_state()` are removed.
-  - Possibility to visualize the model, the input, etc.
-  - Visit the (recently updated and expanded) [documentation](https://egavazzi.github.io/AURORA.jl/dev/) for more details and examples.
+- **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125) [#126](https://github.com/egavazzi/AURORA.jl/pull/126) [#138](https://github.com/egavazzi/AURORA.jl/pull/138)
+  - Simulations are now set up by building an `AuroraModel`, creating an `InputFlux`, constructing an `AuroraSimulation`, and calling `run!(sim)`. The functions `calculate_e_transport()` and `calculate_e_transport_steady_state()` are removed.
+  - Neutral species can be inspected, modified, removed or even added.
+  - Visit the updated online [documentation](https://egavazzi.github.io/AURORA.jl/dev/) for more details and examples.
 - Add error message for when iri calculations return invalid data or when loading invalid data from file [#116](https://github.com/egavazzi/AURORA.jl/pull/116)
 - Switch from IRI2016 to IRI2020 model, solving the issue with recent dates that could not be computed [#117](https://github.com/egavazzi/AURORA.jl/pull/117)
 - Handle invalid iri values at top and bottom ends [#118](https://github.com/egavazzi/AURORA.jl/pull/118)
@@ -12,7 +12,7 @@
 - **Numerical Breaking (small)** Improve physical accuracy of cascading calculations [#132](https://github.com/egavazzi/AURORA.jl/pull/132)
 - **Breaking** Saved files do no longer repeat the last/first time step of each loop across files [#134](https://github.com/egavazzi/AURORA.jl/pull/134)
 - **Breaking** The last `E_centers` is now always ≤ than `E_max` [#136](https://github.com/egavazzi/AURORA.jl/pull/136)
-- Cached cascading and scattering matrices created with different versions of AURORA are now skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
+- Cached cascading and scattering matrices created with different versions of AURORA are now automatically skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/docs/src/10-tutorials/60-modifying-species-and-grids.md
+++ b/docs/src/10-tutorials/60-modifying-species-and-grids.md
@@ -51,7 +51,7 @@ in log-space), but any function works.
 # A plain analytic profile for N₂ (altitude in m → density in m⁻³)
 model.species[:N2].density_profile = h -> 1e18 .* exp.(-(h .- 100e3) ./ 30e3)
 initialize!(model)
-model.species[:N2].density[:N2]
+model.species[:N2].density
 ```
 
 ```julia

--- a/docs/src/10-tutorials/60-modifying-species-and-grids.md
+++ b/docs/src/10-tutorials/60-modifying-species-and-grids.md
@@ -1,0 +1,117 @@
+# Modifying species and grids
+
+An [`AuroraModel`](@ref) is built in **two phases**:
+
+1. `AuroraModel(...)` is *lightweight* — it sets up the grids and reads the background
+   atmosphere, but does **not** compute the expensive data (densities sampled on the grid,
+   cross-sections, phase functions, scattering and cascading matrices).
+2. [`initialize!`](@ref) does that heavy work. It is called automatically by `run!(sim)`.
+
+The gap between the two is an **interception window**: anything you change on the model before
+`initialize!`/`run!` is picked up when the derived data is built. This is how you can customize
+the atmosphere without needing to put your hands in the internals.
+
+## Changing the grids
+
+The grid fields can be reassigned on an existing model. Doing so automatically marks the model
+as uninitialized, so the next `run!(sim)` rebuilds everything for the new grid — no manual
+re-initialization needed.
+
+```@example modular
+using AURORA
+msis_file = find_msis_file()
+iri_file  = find_iri_file()
+
+model = AuroraModel([100, 300], 180:-90:0, 100, msis_file, iri_file)
+initialize!(model)
+model.initialized
+```
+
+```@example modular
+model.energy_grid = EnergyGrid(500)   # also: model.altitude_grid, model.pitch_angle_grid
+model.initialized                     # → false: derived data is now stale
+```
+
+```@example modular
+initialize!(model)                    # rebuilds densities, cross-sections, … for the new grid
+model.energy_grid.n
+```
+
+When a simulation already exists, just change the grid and call `run!(sim)` — it detects the
+change and rebuilds the model and its cache before solving.
+
+## Changing a species' density profile
+
+Each species carries a `density_profile`: any callable mapping altitude (m) to density (m⁻³).
+`initialize!` samples it onto the altitude grid. Built-in options are [`MSISDensity`](@ref) and
+[`VectorDensity`](@ref) (your own altitude/density vectors, that will get pchip interpolated
+in log-space), but any function works.
+
+```@example modular
+# A plain analytic profile for N₂ (altitude in m → density in m⁻³)
+model.species[:N2].density_profile = h -> 1e18 .* exp.(-(h .- 100e3) ./ 30e3)
+initialize!(model)
+model.species[:N2].density[:N2]
+```
+
+```julia
+# Your own measured/downloaded profile, given as vectors:
+model.species[:N2].density_profile = VectorDensity(altitude_m, density_m3)
+
+# Or the default MSIS-backed profile, found/created by find_msis_file():
+model.species[:N2].density_profile = MSISDensity(msis_file, :N2)
+```
+
+## Overriding cross-sections, phase functions, or cascading
+
+The same interception window lets you replace other per-species physics before `initialize!`.
+Set the *generator* (re-evaluated on every `initialize!`, so it tracks grid changes) rather than
+the materialized array where possible:
+
+```julia
+# Phase-function generator: (θ, E) -> (elastic, inelastic) matrices
+model.species[:N2].phase_fcn_generator = my_phase_function
+
+# Cascading: ionization thresholds + a secondary-electron distribution law f(E_s, E_p)
+model.species[:O2].cascading_spec = AURORA.CascadingSpec("O2", [12.07, 16.1], (E_s, E_p) -> 1/(15.2^2 + E_s^2))
+
+# Cross-sections can be pre-populated directly for a non-standard species (see below)
+```
+
+## Adding, removing, or replacing species
+
+Pass an explicit `species` tuple to the constructor. The defaults are
+`N2Species`/`O2Species`/`OSpecies`, which are helper functions accepting
+a density source (i.e. msis_file).
+
+```julia
+# Two species only:
+model = AuroraModel(alt_lims, θ_lims, E_max, msis_file, iri_file;
+                    species = (O2Species(msis_file), OSpecies(msis_file)))
+```
+
+A completely custom species needs its cascading law and a phase-function generator. Because the
+built-in cross-section library only knows N₂/O₂/O, pre-populate the cross-sections and
+excitation levels for a new gas in the interception window:
+
+```julia
+law  = (E_s, E_p) -> 1.0 / (12.0^2 + E_s^2)  # we are completely inventing here
+spec = AURORA.CascadingSpec("Ar", [15.76, 27.63], law)
+argon = NeutralSpecies(:Ar, MSISDensity(msis_file, :Ar);
+                       cascading_spec = spec, phase_fcn_generator = phase_fcn_N2)
+
+model = AuroraModel(alt_lims, θ_lims, E_max, msis_file, iri_file;
+                    species = (N2Species(msis_file), O2Species(msis_file),
+                               OSpecies(msis_file), argon))
+
+model.species[:Ar].cross_sections    = my_sigma_matrix   # [n_levels × n_E]
+model.species[:Ar].excitation_levels = my_levels_matrix  # [n_levels × 2]
+
+run!(AuroraSimulation(model, flux, savedir; mode))
+```
+
+!!! tip
+    Define custom profiles, phase functions, and cascading laws as small `struct`s (functors) or
+    named functions rather than anonymous closures. In-line functions do work, but only 
+    proper structs/named functions can be cleanly saved to file. To be fair we do not save
+    them to file right now, but this is in the plans for improved reproducibility.

--- a/docs/src/20-physics/35-visualizing-the-model.md
+++ b/docs/src/20-physics/35-visualizing-the-model.md
@@ -21,7 +21,14 @@ iri_file = find_iri_file(year=2005, month=10, day=8, hour=22, minute=0,
                          lat=70, lon=19, height=85:1:700)
 
 model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
+initialize!(model)   # build densities, cross-sections, phase functions, and scattering data
 ```
+
+!!! note
+    `AuroraModel(...)` is lightweight — the densities, cross-sections, phase functions, and
+    scattering matrices are computed by [`initialize!`](@ref). `run!(sim)` does this
+    automatically, but here we call `initialize!(model)` ourselves so the diagnostic data
+    exists before plotting.
 
 Generate all figures at once:
 

--- a/ext/src/plot_model.jl
+++ b/ext/src/plot_model.jl
@@ -38,7 +38,7 @@ end
 function _plot_atmosphere(model)
     h_km = model.altitude_grid.h ./ 1e3
     iono = model.ionosphere
-    nd = AURORA.n_neutrals(iono)
+    nd = AURORA.n_neutrals(model)
 
     fig = Figure(size = (800, 600))
 
@@ -66,16 +66,15 @@ end
 # Energy levels
 # ======================================================================================== #
 function _plot_energy_levels(model)
-    levels = model.cross_sections.collision_levels
+    titles = Dict(:N2 => "N₂", :O2 => "O₂", :O => "O")
 
     fig = Figure(size = (800, 600))
-    ax1 = Axis(fig[1, 1]; ylabel="Excitation energy (eV)", title="N₂")
-    ax2 = Axis(fig[1, 2]; title="O₂")
-    ax3 = Axis(fig[1, 3]; title="O")
+    axs = [Axis(fig[1, i]; title=titles[sp.name]) for (i, sp) in enumerate(model.species)]
+    axs[1].ylabel = "Excitation energy (eV)"
 
-    for (ax, data) in zip([ax1, ax2, ax3],
-                          [levels.N2_levels, levels.O2_levels, levels.O_levels])
-        for i in axes(data, 1)
+    for (ax, sp) in zip(axs, model.species)
+        data = sp.excitation_levels
+        for i in 1:size(data, 1)
             lines!(ax, [0, 1], data[i, 1] .* [1, 1]; linewidth=2)
         end
         xlims!(ax, 0, 1)
@@ -106,14 +105,14 @@ end
 # ======================================================================================== #
 function _plot_cross_sections(model)
     E = model.energy_grid.E_centers
-    σ = model.cross_sections.σ_neutrals
+    titles = Dict(:N2 => "σ N₂", :O2 => "σ O₂", :O => "σ O")
 
     fig = Figure(size=(1800, 800))
 
-    for (idx, (species, σ_sp, title_str)) in enumerate([
-            ("N2", σ.σ_N2, "σ N₂"),
-            ("O2", σ.σ_O2, "σ O₂"),
-            ("O",  σ.σ_O,  "σ O")])
+    for (idx, sp) in enumerate(model.species)
+        species  = String(sp.name)
+        σ_sp     = sp.cross_sections
+        title_str = titles[sp.name]
 
         names = AURORA.get_level_names(species)
         n_levels = length(names)

--- a/ext/src/plot_model.jl
+++ b/ext/src/plot_model.jl
@@ -36,18 +36,21 @@ end
 # Atmosphere
 # ======================================================================================== #
 function _plot_atmosphere(model)
-    h_km = model.altitude_grid.h ./ 1e3
-    iono = model.ionosphere
-    nd = AURORA.n_neutrals(model)
+    h_km  = model.altitude_grid.h ./ 1e3
+    iono  = model.ionosphere
+    styles = (:solid, :dash, :dashdot, :dot)
 
     fig = Figure(size = (800, 600))
 
     ax1 = Axis(fig[1, 1]; xlabel="(m⁻³)", ylabel="height (km)",
-               title="MSIS neutral density", xscale=log10,
+               title="Neutral density", xscale=log10,
                xticks=LogTicks(LinearTicks(9)))
-    lines!(ax1, nd.nN2, h_km; linewidth=2, label="N₂")
-    lines!(ax1, nd.nO2, h_km; linewidth=2, linestyle=:dash, label="O₂")
-    lines!(ax1, nd.nO, h_km; linewidth=2, linestyle=:dashdot, label="O")
+    for (i, sp) in enumerate(model.species)
+        lines!(ax1, sp.density, h_km;
+               linewidth  = 2,
+               linestyle  = styles[mod1(i, length(styles))],
+               label      = String(sp.name))
+    end
     xlims!(ax1, 1e12, 1e20)
     ylims!(ax1, h_km[1] - 10, h_km[end] + 10)
     axislegend(ax1, "Densities"; position=:rt)

--- a/ext/src/plot_model.jl
+++ b/ext/src/plot_model.jl
@@ -12,17 +12,17 @@ function AURORA.plot_model(model::AURORA.AuroraModel; panels=[:all])
 
     for panel in panels
         if panel === :atmosphere
-            figs[:atmosphere] = _plot_atmosphere(model)
+            figs[:atmosphere] = plot_atmosphere(model)
         elseif panel === :energy_levels
-            figs[:energy_levels] = _plot_energy_levels(model)
+            figs[:energy_levels] = plot_energy_levels(model)
         elseif panel === :energy_grid
-            figs[:energy_grid] = _plot_energy_grid(model)
+            figs[:energy_grid] = plot_energy_grid(model)
         elseif panel === :cross_sections
-            figs[:cross_sections] = _plot_cross_sections(model)
+            figs[:cross_sections] = plot_cross_sections(model)
         elseif panel === :phase_functions
-            figs[:phase_functions] = _plot_phase_functions(model)
+            figs[:phase_functions] = plot_phase_functions(model)
         elseif panel === :scattering
-            figs[:scattering] = _plot_scattering(model)
+            figs[:scattering] = plot_scattering(model)
         else
             @warn "Unknown panel: $panel. Available panels: $ALL_PANELS"
         end
@@ -35,7 +35,7 @@ end
 # ======================================================================================== #
 # Atmosphere
 # ======================================================================================== #
-function _plot_atmosphere(model)
+function plot_atmosphere(model)
     h_km  = model.altitude_grid.h ./ 1e3
     iono  = model.ionosphere
     styles = (:solid, :dash, :dashdot, :dot)
@@ -68,7 +68,7 @@ end
 # ======================================================================================== #
 # Energy levels
 # ======================================================================================== #
-function _plot_energy_levels(model)
+function plot_energy_levels(model)
     titles = Dict(:N2 => "N₂", :O2 => "O₂", :O => "O")
 
     fig = Figure(size = (800, 600))
@@ -90,7 +90,7 @@ end
 # ======================================================================================== #
 # Energy grid
 # ======================================================================================== #
-function _plot_energy_grid(model)
+function plot_energy_grid(model)
     E_centers = model.energy_grid.E_centers
     ΔE = model.energy_grid.ΔE
 
@@ -106,7 +106,7 @@ end
 # ======================================================================================== #
 # Cross-sections
 # ======================================================================================== #
-function _plot_cross_sections(model)
+function plot_cross_sections(model)
     E = model.energy_grid.E_centers
     titles = Dict(:N2 => "σ N₂", :O2 => "σ O₂", :O => "σ O")
 
@@ -221,7 +221,7 @@ end
 # ======================================================================================== #
 # Phase functions
 # ======================================================================================== #
-function _plot_phase_functions(model)
+function plot_phase_functions(model)
     E = model.energy_grid.E_centers
     θ = deg2rad.(0:180)
 
@@ -273,7 +273,7 @@ end
 # ======================================================================================== #
 # Scattering matrices
 # ======================================================================================== #
-function _plot_scattering(model)
+function plot_scattering(model)
     P_scatter = model.scattering.P_scatter
     θ_lims = model.pitch_angle_grid.θ_lims
     n_beams = model.pitch_angle_grid.n_beams

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -32,7 +32,7 @@ include("physics/cascading_cache.jl")
 export clear_cascading_cache!
 
 include("physics/species.jl")
-export NeutralSpecies
+export NeutralSpecies, MSISDensity, VectorDensity
 
 include("model.jl")
 export AuroraModel, make_altitude_grid, make_energy_grid, n_neutrals

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -7,7 +7,7 @@ include("grids/pitch_angle_grid.jl")
 export AbstractGrid, AltitudeGrid, EnergyGrid, PitchAngleGrid
 
 include("ionosphere/ionosphere.jl")
-export Ionosphere, n_neutrals
+export Ionosphere
 include("ionosphere/iri/iri.jl")
 include("ionosphere/msis/msis.jl")
 export find_msis_file, find_nrlmsis_file
@@ -18,7 +18,6 @@ include("physics/cross_sections/e_O2_cross_sections.jl")
 include("physics/cross_sections/e_O_cross_sections.jl")
 include("physics/cross_sections/emission_cross_sections.jl")
 include("physics/cross_sections/cross_sections.jl")
-export CrossSectionData
 
 include("physics/cache_policy.jl")
 export CachePolicy
@@ -36,7 +35,7 @@ include("physics/species.jl")
 export NeutralSpecies
 
 include("model.jl")
-export AuroraModel, make_altitude_grid, make_energy_grid
+export AuroraModel, make_altitude_grid, make_energy_grid, n_neutrals
 
 include("input/spectra.jl")
 include("input/modulations.jl")

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -28,6 +28,13 @@ export ScatteringData, clear_scattering_cache!
 include("physics/phase_functions.jl")
 export phase_fcn_N2, phase_fcn_O2, phase_fcn_O, convert_phase_fcn_to_3D
 
+include("physics/cascading.jl")
+include("physics/cascading_cache.jl")
+export clear_cascading_cache!
+
+include("physics/species.jl")
+export NeutralSpecies
+
 include("model.jl")
 export AuroraModel, make_altitude_grid, make_energy_grid
 
@@ -42,9 +49,6 @@ export Ie_top_from_file
 include("solvers/transport_matrices.jl")
 include("solvers/matrix_building.jl")
 
-include("physics/cascading.jl")
-include("physics/cascading_cache.jl")
-export clear_cascading_cache!
 include("physics/energy_degradation.jl")
 
 include("solvers/sparse_indexing.jl")

--- a/src/AURORA.jl
+++ b/src/AURORA.jl
@@ -33,9 +33,10 @@ export clear_cascading_cache!
 
 include("physics/species.jl")
 export NeutralSpecies, MSISDensity, VectorDensity
+export N2Species, O2Species, OSpecies
 
 include("model.jl")
-export AuroraModel, make_altitude_grid, make_energy_grid, n_neutrals
+export AuroraModel, make_altitude_grid, make_energy_grid
 
 include("input/spectra.jl")
 include("input/modulations.jl")

--- a/src/input/input_flux.jl
+++ b/src/input/input_flux.jl
@@ -52,15 +52,15 @@ function InputFlux(spectrum::AbstractSpectrum, modulation::AbstractModulation;
               "The file already contains the complete flux. " *
               "Use ConstantModulation() (the default).")
     end
-    beams_vec = _to_beam_vector(beams)
+    beams_vec = to_beam_vector(beams)
     InputFlux{typeof(spectrum), typeof(modulation)}(
         spectrum, modulation, beams_vec, Float64(z_source))
 end
 
 # Internal: convert any beam specification to Vector{Int}
-_to_beam_vector(b::Int) = [b]
-_to_beam_vector(b::AbstractRange{<:Integer}) = collect(Int, b)
-_to_beam_vector(b::AbstractVector{<:Integer}) = convert(Vector{Int}, b)
+to_beam_vector(b::Int) = [b]
+to_beam_vector(b::AbstractRange{<:Integer}) = collect(Int, b)
+to_beam_vector(b::AbstractVector{<:Integer}) = convert(Vector{Int}, b)
 
 
 function Base.show(io::IO, flux::InputFlux)
@@ -215,7 +215,7 @@ end
 ## ====================================================================================== ##
 
 """
-    _flat_spectrum(IeE_tot_eV, E, dE, E_min)
+    flat_spectrum(IeE_tot_eV, E, dE, E_min)
 
 Compute a flat (constant) differential number flux spectrum above E_min, normalized so that
 the total energy flux equals IeE_tot_eV.
@@ -223,7 +223,7 @@ the total energy flux equals IeE_tot_eV.
 Returns a vector of differential number flux per eV (#e⁻/m²/s/eV) for each energy bin.
 The flux is zero below E_min.
 """
-function _flat_spectrum(IeE_tot_eV, E_centers, ΔE, E_min)
+function flat_spectrum(IeE_tot_eV, E_centers, ΔE, E_min)
     # Find first index where bin lower edge <= E_min
     i_Emin = findlast((E_centers .- ΔE./2) .<= E_min)
     if isnothing(i_Emin)
@@ -242,7 +242,7 @@ end
 
 
 """
-    _gaussian_spectrum(IeE_tot_eV, E, dE, E₀, ΔE)
+    gaussian_spectrum(IeE_tot_eV, E, dE, E₀, ΔE)
 
 Compute a Gaussian differential number flux spectrum centered at E₀ with width ΔE,
 normalized so that the total energy flux equals IeE_tot_eV.
@@ -251,7 +251,7 @@ The Gaussian shape is: Φ(E) ∝ exp(-(E - E₀)² / ΔE²)
 
 Returns a vector of differential number flux per eV (#e⁻/m²/s/eV) for each energy bin.
 """
-function _gaussian_spectrum(IeE_tot_eV, E_centers, ΔE, E₀, ΔE_gauss)
+function gaussian_spectrum(IeE_tot_eV, E_centers, ΔE, E₀, ΔE_gauss)
     # Unnormalized Gaussian shape
     Φ_shape = exp.(-(E_centers .- E₀).^2 ./ ΔE_gauss^2)
 

--- a/src/input/modulations.jl
+++ b/src/input/modulations.jl
@@ -204,11 +204,11 @@ Square-wave modulation: alternates between `(1 - amplitude)` and `1`.
 """
 function apply_modulation(mod::SquareFlickering, t_shifted)
     # Square wave helper function
-    function _square(x)
+    function square_wave(x)
         ifelse(mod2pi(x) < π, 1.0, -1.0)
     end
     # Base pattern: (1 + square(...))/2 goes from 0 to 1
-    base_modulation = (1.0 .+ _square.(2π * mod.f .* t_shifted .- π/2)) ./ 2
+    base_modulation = (1.0 .+ square_wave.(2π * mod.f .* t_shifted .- π/2)) ./ 2
     # Scale by amplitude and shift
     modulated = (1.0 - mod.amplitude) .+ mod.amplitude .* base_modulation
     # Apply onset (Heaviside at t=0)
@@ -222,5 +222,5 @@ end
 Smooth onset using a C∞-smooth transition function over `[t_start, t_end]`.
 """
 function apply_modulation(mod::SmoothOnset, t_shifted)
-    return _smooth_transition.(t_shifted, mod.t_start, mod.t_end)
+    return smooth_transition.(t_shifted, mod.t_start, mod.t_end)
 end

--- a/src/input/spectra.jl
+++ b/src/input/spectra.jl
@@ -215,7 +215,7 @@ function evaluate_spectrum(spec::FlatSpectrum, model::AuroraModel)
 
     qₑ = 1.602176620898e-19
     IeE_tot_eV = spec.IeE_tot / qₑ
-    return _flat_spectrum(IeE_tot_eV, E_centers, ΔE, spec.E_min)
+    return flat_spectrum(IeE_tot_eV, E_centers, ΔE, spec.E_min)
 end
 
 
@@ -230,7 +230,7 @@ function evaluate_spectrum(spec::GaussianSpectrum, model::AuroraModel)
 
     qₑ = 1.602176620898e-19
     IeE_tot_eV = spec.IeE_tot / qₑ
-    return _gaussian_spectrum(IeE_tot_eV, E_centers, ΔE, spec.E₀, spec.ΔE)
+    return gaussian_spectrum(IeE_tot_eV, E_centers, ΔE, spec.E₀, spec.ΔE)
 end
 
 

--- a/src/ionosphere/ionosphere.jl
+++ b/src/ionosphere/ionosphere.jl
@@ -1,11 +1,10 @@
 """
     Ionosphere{FT, V<:AbstractVector{FT}}
 
-Electron and thermal background: electron density and temperature plus neutral temperature.
+Electron background: electron density and temperature.
 Neutral species densities are owned by the individual [`NeutralSpecies`](@ref) objects.
 """
 struct Ionosphere{FT, V<:AbstractVector{FT}}
-    Tn::V
     Te::V
     ne::V
     msis_file::String
@@ -14,12 +13,9 @@ end
 
 function Ionosphere(msis_file::AbstractString, iri_file::AbstractString,
                     h_atm::AbstractVector)
-    msis_raw = load_msis(msis_file)
-    msis = interpolate_msis_to_grid(msis_raw.data, h_atm)
-    Tn = msis.T
     ne, Te = load_electron_densities(iri_file, h_atm)
-    FT = eltype(Tn)
-    return Ionosphere{FT, typeof(Tn)}(Tn, Te, ne, string(msis_file), string(iri_file))
+    FT = eltype(Te)
+    return Ionosphere{FT, typeof(Te)}(Te, ne, string(msis_file), string(iri_file))
 end
 
 """
@@ -50,16 +46,15 @@ function load_electron_densities(iri_file, h_atm)
 end
 
 function Base.show(io::IO, iono::Ionosphere)
-    print(io, "Ionosphere($(length(iono.Tn)) altitudes)")
+    print(io, "Ionosphere($(length(iono.ne)) altitudes)")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", iono::Ionosphere)
-    nz = length(iono.Tn)
+    nz = length(iono.ne)
     println(io, "Ionosphere:")
     println(io, "├── Altitudes: $(nz)")
     println(io, "├── MSIS file: $(basename(iono.msis_file))")
     println(io, "├── IRI  file: $(basename(iono.iri_file))")
-    println(io, "├── Max Tn:    $(round(maximum(iono.Tn), sigdigits=3)) K")
     println(io, "├── Max Te:    $(round(maximum(iono.Te), sigdigits=3)) K")
     print(io,   "└── Max ne:    $(round(maximum(iono.ne), sigdigits=3)) m⁻³")
 end

--- a/src/ionosphere/ionosphere.jl
+++ b/src/ionosphere/ionosphere.jl
@@ -1,5 +1,3 @@
-using SpecialFunctions: erf
-
 """
     Ionosphere{FT, V<:AbstractVector{FT}}
 
@@ -22,60 +20,6 @@ function Ionosphere(msis_file::AbstractString, iri_file::AbstractString,
     ne, Te = load_electron_densities(iri_file, h_atm)
     FT = eltype(Tn)
     return Ionosphere{FT, typeof(Tn)}(Tn, Te, ne, string(msis_file), string(iri_file))
-end
-
-"""
-    load_neutral_densities(msis_file, h_atm)
-
-Load the neutral densities and temperature from a MSIS file that was generated and saved
-using AURORA's MSIS interface. Then interpolate the profiles over AURORA's altitude grid.
-
-Upper boundary conditions are applied to smoothly transition the densities to zero.
-
-# Calling
-`n_neutrals, Tn = load_neutral_densities(msis_file, h_atm)`
-
-# Inputs
-- `msis_file`: absolute path to the msis file to read n_neutrals and Tn from. String
-- `h_atm`: altitude (m). Vector [nZ]
-
-# Returns
-- `n_neutrals`: neutral densities (m⁻³). Named tuple of vectors ([nZ], ..., [nZ])
-- `Tn`: neutral temperature (K). Vector [nZ]
-
-# See also
-[`load_msis`](@ref), [`interpolate_msis_to_grid`](@ref)
-"""
-function load_neutral_densities(msis_file, h_atm)
-    msis_raw = load_msis(msis_file)
-    msis = interpolate_msis_to_grid(msis_raw.data, h_atm)
-    nN2 = msis.N2
-    nO2 = msis.O2
-    nO = msis.O
-
-    # Apply upper boundary conditions to smoothly transition densities to zero
-    # Set the last 3 points to zero
-    nN2[end-2:end] .= 0
-    nO2[end-2:end] .= 0
-    nO[end-2:end] .= 0
-
-    # Apply smooth transition using error function for the 3 points below
-    erf_factor = (erf.((1:-1:-1) / 2) .+ 1) / 2
-    nN2[end-5:end-3] .= erf_factor .* nN2[end-5:end-3]
-    nO2[end-5:end-3] .= erf_factor .* nO2[end-5:end-3]
-    nO[end-5:end-3] .= erf_factor .* nO[end-5:end-3]
-
-    # Ensure no negative densities
-    if any(nN2 .< 0) || any(nO2 .< 0) || any(nO .< 0)
-        @warn "Negative densities found. They were set to 0, but you might want to check " *
-              "why that happened"
-        nN2[nN2 .< 0] .= 0
-        nO2[nO2 .< 0] .= 0
-        nO[nO .< 0] .= 0
-    end
-
-    n_neutrals = (; nN2, nO2, nO)
-    return n_neutrals, msis.T
 end
 
 """

--- a/src/ionosphere/ionosphere.jl
+++ b/src/ionosphere/ionosphere.jl
@@ -3,12 +3,10 @@ using SpecialFunctions: erf
 """
     Ionosphere{FT, V<:AbstractVector{FT}}
 
-Atmospheric state containing neutral and electron densities and temperatures.
+Electron and thermal background: electron density and temperature plus neutral temperature.
+Neutral species densities are owned by the individual [`NeutralSpecies`](@ref) objects.
 """
 struct Ionosphere{FT, V<:AbstractVector{FT}}
-    nN2::V
-    nO2::V
-    nO::V
     Tn::V
     Te::V
     ne::V
@@ -18,22 +16,13 @@ end
 
 function Ionosphere(msis_file::AbstractString, iri_file::AbstractString,
                     h_atm::AbstractVector)
-    n_neutrals, Tn = load_neutral_densities(msis_file, h_atm)
+    msis_raw = load_msis(msis_file)
+    msis = interpolate_msis_to_grid(msis_raw.data, h_atm)
+    Tn = msis.T
     ne, Te = load_electron_densities(iri_file, h_atm)
     FT = eltype(Tn)
-    return Ionosphere{FT, typeof(Tn)}(
-        n_neutrals.nN2, n_neutrals.nO2, n_neutrals.nO,
-        Tn, Te, ne,
-        string(msis_file), string(iri_file)
-    )
+    return Ionosphere{FT, typeof(Tn)}(Tn, Te, ne, string(msis_file), string(iri_file))
 end
-
-"""
-    n_neutrals(iono::Ionosphere)
-
-Return neutral densities as a NamedTuple `(; nN2, nO2, nO)`.
-"""
-n_neutrals(iono::Ionosphere) = (; nN2=iono.nN2, nO2=iono.nO2, nO=iono.nO)
 
 """
     load_neutral_densities(msis_file, h_atm)
@@ -117,16 +106,16 @@ function load_electron_densities(iri_file, h_atm)
 end
 
 function Base.show(io::IO, iono::Ionosphere)
-    print(io, "Ionosphere($(length(iono.nN2)) altitudes)")
+    print(io, "Ionosphere($(length(iono.Tn)) altitudes)")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", iono::Ionosphere)
-    nz = length(iono.nN2)
+    nz = length(iono.Tn)
     println(io, "Ionosphere:")
     println(io, "├── Altitudes: $(nz)")
     println(io, "├── MSIS file: $(basename(iono.msis_file))")
     println(io, "├── IRI  file: $(basename(iono.iri_file))")
-    println(io, "├── Max n(N2): $(round(maximum(iono.nN2), sigdigits=3)) m^-3")
-    println(io, "├── Max n(O2): $(round(maximum(iono.nO2), sigdigits=3)) m^-3")
-    print(io, "└── Max n(O):  $(round(maximum(iono.nO), sigdigits=3)) m^-3")
+    println(io, "├── Max Tn:    $(round(maximum(iono.Tn), sigdigits=3)) K")
+    println(io, "├── Max Te:    $(round(maximum(iono.Te), sigdigits=3)) K")
+    print(io,   "└── Max ne:    $(round(maximum(iono.ne), sigdigits=3)) m⁻³")
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,77 +1,102 @@
 """
-    AuroraModel{AG, EG, PAG, SD, IO, SP, FT, V}
+    AuroraModel{AG, EG, PAG, IO, SP, FT, V}
 
 Container for the grids, atmosphere, and collision data used by an AURORA simulation.
+
+Construct cheaply with `AuroraModel(...)`, then call `initialize!(model)` (or `run!(sim)`)
+to perform the heavy setup: scattering matrices, species densities, cross sections, and
+cascading transfer matrices.
 """
-struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
-                   SD<:ScatteringData, IO<:Ionosphere,
-                   SP<:Tuple{Vararg{NeutralSpecies}},
-                   FT, V<:AbstractVector{FT}}
+mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
+                            IO<:Ionosphere,
+                            SP<:Tuple{Vararg{NeutralSpecies}},
+                            FT, V<:AbstractVector{FT}}
     altitude_grid::AG
     energy_grid::EG
     pitch_angle_grid::PAG
-    scattering::SD
+    scattering::Union{Nothing, ScatteringData}   # nothing until initialize!(model)
     ionosphere::IO
     species::SP
     B_angle_to_zenith::FT
     s_field::V
+    initialized::Bool
 end
 
 """
-    AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0;
-                verbose=true, cache_policy=CachePolicy())
+    AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0)
 
-Load the atmosphere, the energy grid, and the collision data into an `AuroraModel`.
+Build a lightweight `AuroraModel`. Only the grids and ionosphere are set up; the expensive
+computation (scattering matrices, species densities, cross sections, cascading data) is
+deferred to `initialize!(model)`, which is called automatically by `run!(sim)`.
 
-## Calling
-`model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)`
+Between construction and initialization you can freely mutate species density profiles:
+```julia
+model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+model.species[1].density_profile = VectorDensity(h, my_n2)
+run!(sim)   # initialize!(model) picks up the custom profile here
+```
 
 ## Inputs
-- `altitude_lims`: the altitude limits, in km, for the bottom and top of the ionosphere in our simulation
-- `θ_lims`: pitch-angle limits of the electron beams (e.g. 180:-10:0), where 180°
-    corresponds to field aligned down, and 0° field aligned up. Vector [n_beam]
-- `E_max`: upper limit for the energy grid (in eV)
-- `msis_file`: path to the msis file to use
-- `iri_file`: path to the iri file to use
-- `B_angle_to_zenith`: angle between magnetic field and zenith (degrees)
-- `verbose=true`: print progress messages when loading stuff
-- `cache_policy=CachePolicy()`: controls reuse and persistence of the internal cascading and scattering cache
+- `altitude_lims`: altitude limits (km) for the bottom and top of the ionosphere
+- `θ_lims`: pitch-angle beam limits (e.g. `180:-10:0`), 180° = field-aligned down
+- `E_max`: upper energy-grid limit (eV)
+- `msis_file`: path to the MSIS atmosphere file
+- `iri_file`: path to the IRI ionosphere file
+- `B_angle_to_zenith`: angle between the magnetic field and zenith (degrees, default 0)
 
 ## Returns
-An `AuroraModel` with fields:
-- `altitude_grid::AltitudeGrid`
-- `energy_grid::EnergyGrid`
-- `pitch_angle_grid::PitchAngleGrid`
-- `scattering::ScatteringData`
-- `ionosphere::Ionosphere`
-- `species::Tuple{NeutralSpecies, ...}`
-- `B_angle_to_zenith::Real`
-- `s_field::Vector`
+An uninitialized `AuroraModel`. Call `initialize!(model)` or `run!(sim)` to complete setup.
 """
-function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0;
-                     verbose=true, cache_policy::CachePolicy = CachePolicy())
-    altitude_grid = AltitudeGrid(altitude_lims[1], altitude_lims[2])
-    energy_grid = EnergyGrid(E_max)
+function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0)
+    altitude_grid    = AltitudeGrid(altitude_lims[1], altitude_lims[2])
+    energy_grid      = EnergyGrid(E_max)
     pitch_angle_grid = PitchAngleGrid(θ_lims)
-    scattering = ScatteringData(pitch_angle_grid; verbose, policy=cache_policy)
-    ionosphere = Ionosphere(msis_file, iri_file, altitude_grid.h)
-    species = (
-        N2Species(altitude_grid, energy_grid, scattering, msis_file),
-        O2Species(altitude_grid, energy_grid, scattering, msis_file),
-        OSpecies(altitude_grid, energy_grid, scattering, msis_file),
-    )
-    s_field = altitude_grid.h ./ cosd(B_angle_to_zenith)
+    ionosphere       = Ionosphere(msis_file, iri_file, altitude_grid.h)
+    species          = (N2Species(msis_file), O2Species(msis_file), OSpecies(msis_file))
+    s_field          = altitude_grid.h ./ cosd(B_angle_to_zenith)
 
     FT = promote_type(eltype(s_field), typeof(B_angle_to_zenith))
 
     return AuroraModel{typeof(altitude_grid), typeof(energy_grid), typeof(pitch_angle_grid),
-                       typeof(scattering), typeof(ionosphere),
-                       typeof(species),
+                       typeof(ionosphere), typeof(species),
                        FT, typeof(s_field)}(
         altitude_grid, energy_grid, pitch_angle_grid,
-        scattering, ionosphere, species,
-        FT(B_angle_to_zenith), s_field
+        nothing, ionosphere, species,
+        FT(B_angle_to_zenith), s_field, false
     )
+end
+
+"""
+    initialize!(model::AuroraModel; verbose=true, policy=CachePolicy())
+
+Perform all heavy one-time setup for `model`:
+1. Compute (or load from cache) the scattering matrices.
+2. For each species: sample the density profile, load cross sections and excitation levels,
+   build phase function matrices, and load/compute cascading transfer matrices.
+
+Called automatically by `initialize!(sim)` → `run!(sim)`. Call it directly when you need
+access to `model.scattering` or `model.species[i].density` before constructing a simulation.
+"""
+function initialize!(model::AuroraModel;
+                     verbose::Bool = true,
+                     policy::CachePolicy = CachePolicy())
+    model.scattering = ScatteringData(model.pitch_angle_grid; verbose, policy)
+
+    h  = model.altitude_grid.h
+    eg = model.energy_grid
+    θ  = model.scattering.θ_scatter
+
+    for sp in model.species
+        sp.density           = collect(Float64, sp.density_profile(h))
+        apply_density_boundary!(sp.density)
+        name_str             = String(sp.name)
+        sp.cross_sections    = get_cross_section(name_str, eg.E_centers)
+        sp.excitation_levels = load_excitation_threshold_for(name_str)
+        sp.phase_fcn         = sp.phase_fcn_generator(θ, eg.E_centers)
+        load_or_compute_cascading!(sp.cascading_data, eg; verbose, policy)
+    end
+    model.initialized = true
+    return nothing
 end
 
 """
@@ -90,11 +115,11 @@ function Base.show(io::IO, model::AuroraModel)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", model::AuroraModel)
-    println(io, "AuroraModel:")
+    println(io, "AuroraModel", model.initialized ? "" : " (not initialized)", ":")
     println(io, "├── ", model.altitude_grid)
     println(io, "├── ", model.energy_grid)
     println(io, "├── ", model.pitch_angle_grid)
-    println(io, "├── ", model.scattering)
+    println(io, "├── ", isnothing(model.scattering) ? "ScatteringData: (not initialized)" : model.scattering)
     println(io, "├── ", model.ionosphere)
     println(io, "├── Species: ", join((String(sp.name) for sp in model.species), ", "))
     print(io, "└── B angle to zenith: $(model.B_angle_to_zenith)°")

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,10 +1,10 @@
 """
-    AuroraModel{AG, EG, PAG, SD, IO, CS, SP, FT, V}
+    AuroraModel{AG, EG, PAG, SD, IO, SP, FT, V}
 
 Container for the grids, atmosphere, and collision data used by an AURORA simulation.
 """
 struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
-                   SD<:ScatteringData, IO<:Ionosphere, CS<:CrossSectionData,
+                   SD<:ScatteringData, IO<:Ionosphere,
                    SP<:Tuple{Vararg{NeutralSpecies}},
                    FT, V<:AbstractVector{FT}}
     altitude_grid::AG
@@ -12,7 +12,6 @@ struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
     pitch_angle_grid::PAG
     scattering::SD
     ionosphere::IO
-    cross_sections::CS
     species::SP
     B_angle_to_zenith::FT
     s_field::V
@@ -45,7 +44,7 @@ An `AuroraModel` with fields:
 - `pitch_angle_grid::PitchAngleGrid`
 - `scattering::ScatteringData`
 - `ionosphere::Ionosphere`
-- `cross_sections::CrossSectionData`
+- `species::Tuple{NeutralSpecies, ...}`
 - `B_angle_to_zenith::Real`
 - `s_field::Vector`
 """
@@ -56,7 +55,6 @@ function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle
     pitch_angle_grid = PitchAngleGrid(θ_lims)
     scattering = ScatteringData(pitch_angle_grid; verbose, policy=cache_policy)
     ionosphere = Ionosphere(msis_file, iri_file, altitude_grid.h)
-    cross_sections = CrossSectionData(energy_grid)
     species = (
         N2Species(altitude_grid, energy_grid, scattering, msis_file),
         O2Species(altitude_grid, energy_grid, scattering, msis_file),
@@ -67,14 +65,25 @@ function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle
     FT = promote_type(eltype(s_field), typeof(B_angle_to_zenith))
 
     return AuroraModel{typeof(altitude_grid), typeof(energy_grid), typeof(pitch_angle_grid),
-                       typeof(scattering), typeof(ionosphere), typeof(cross_sections),
+                       typeof(scattering), typeof(ionosphere),
                        typeof(species),
                        FT, typeof(s_field)}(
         altitude_grid, energy_grid, pitch_angle_grid,
-        scattering, ionosphere, cross_sections, species,
+        scattering, ionosphere, species,
         FT(B_angle_to_zenith), s_field
     )
 end
+
+"""
+    n_neutrals(model::AuroraModel)
+
+Return neutral densities as a NamedTuple `(; nN2, nO2, nO)` sourced from the model's species.
+"""
+n_neutrals(model::AuroraModel) = (;
+    nN2 = model.species[1].density,
+    nO2 = model.species[2].density,
+    nO  = model.species[3].density,
+)
 
 function Base.show(io::IO, model::AuroraModel)
     print(io, "AuroraModel($(model.altitude_grid), $(model.energy_grid), $(model.pitch_angle_grid))")
@@ -87,7 +96,6 @@ function Base.show(io::IO, ::MIME"text/plain", model::AuroraModel)
     println(io, "├── ", model.pitch_angle_grid)
     println(io, "├── ", model.scattering)
     println(io, "├── ", model.ionosphere)
-    println(io, "├── ", model.cross_sections)
     println(io, "├── Species: ", join((String(sp.name) for sp in model.species), ", "))
     print(io, "└── B angle to zenith: $(model.B_angle_to_zenith)°")
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -2,22 +2,6 @@
     AuroraModel{AG, EG, PAG, SD, IO, SP, FT, V}
 
 Container for the grids, atmosphere, and collision data used by an AURORA simulation.
-
-Construct cheaply with `AuroraModel(...)`, then call `initialize!(model)` (or `run!(sim)`)
-to perform the heavy setup: scattering matrices, species densities, cross sections, and
-cascading transfer matrices.
-
-The grid fields (`altitude_grid`, `energy_grid`, `pitch_angle_grid`) and `B_angle_to_zenith`
-can be reassigned on an existing model. Doing so automatically marks the model as
-uninitialized, so the next `run!(sim)` rebuilds all derived data *and* the simulation cache
-for the new grid:
-```julia
-model.altitude_grid = AltitudeGrid(80, 500)
-run!(sim)              # detects the change, rebuilds model + cache, then solves
-```
-You can still call `initialize!(model)` explicitly if you want the rebuilt data (scattering,
-densities, …) available before constructing a simulation. If you do that *after* a simulation
-already exists, follow it with `initialize!(sim)` (or just change the grid and call `run!`).
 """
 mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
                             SD<:ScatteringData, IO<:Ionosphere,
@@ -109,19 +93,14 @@ end
 """
     initialize!(model::AuroraModel; verbose=true, policy=CachePolicy())
 
-Perform all heavy setup for `model`.
-Always rebuilds from the current grid fields, so it can (and should) be called after
-reassigning `model.altitude_grid` or `model.energy_grid`.
-It does the following:
-1. Recompute `s_field` and `ionosphere` from the current altitude grid.
+Perform all heavy setup for `model`:
+1. Compute `s_field` and `ionosphere` from the current altitude grid.
 2. Compute (or load from cache) the scattering matrices.
 3. For each species: sample the density profile, load cross sections and excitation levels
    (skipped if already pre-populated), build phase functions, and load/compute cascading
    transfer matrices.
 
-Called automatically by `initialize!(sim)` → `run!(sim)`. Call it directly when you need
-access to `model.scattering` or `model.species[i].density` before constructing a simulation,
-or after changing a grid field.
+Called internally by `initialize!(sim)` and/or `run!(sim)`.
 """
 function initialize!(model::AuroraModel;
                      verbose::Bool = true,

--- a/src/model.jl
+++ b/src/model.jl
@@ -23,18 +23,12 @@ mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid
 end
 
 """
-    AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0)
+    AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0;
+                species = (N2Species(msis_file), O2Species(msis_file), OSpecies(msis_file)))
 
 Build a lightweight `AuroraModel`. Only the grids and ionosphere are set up; the expensive
 computation (scattering matrices, species densities, cross sections, cascading data) is
 deferred to `initialize!(model)`, which is called automatically by `run!(sim)`.
-
-Between construction and initialization you can freely mutate species density profiles:
-```julia
-model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
-model.species[1].density_profile = VectorDensity(h, my_n2)
-run!(sim)   # initialize!(model) picks up the custom profile here
-```
 
 ## Inputs
 - `altitude_lims`: altitude limits (km) for the bottom and top of the ionosphere
@@ -44,24 +38,44 @@ run!(sim)   # initialize!(model) picks up the custom profile here
 - `iri_file`: path to the IRI ionosphere file
 - `B_angle_to_zenith`: angle between the magnetic field and zenith (degrees, default 0)
 
+## Keyword Arguments
+- `species`: tuple (or any iterable) of [`NeutralSpecies`](@ref) instances that the model
+  should simulate. Defaults to the standard atmosphere: N₂, O₂, O from `msis_file`.
+  Pass a custom tuple to add, remove, or replace species:
+  ```julia
+  # Only two species:
+  model = AuroraModel(...; species = (O2Species(msis_file), OSpecies(msis_file)))
+
+  # Four species — custom 4th gas with pre-populated cross sections:
+  custom_sp = NeutralSpecies(:MyGas, my_density_profile;
+                             cascading_spec = my_spec, phase_fcn_generator = phase_fcn_N2)
+  model = AuroraModel(...; species = (N2Species(msis_file), O2Species(msis_file),
+                                      OSpecies(msis_file),  custom_sp))
+  # Interception window: pre-populate custom cross sections before run!/initialize!
+  model.species[end].cross_sections    = my_sigma_matrix   # [n_levels × n_E]
+  model.species[end].excitation_levels = my_levels_matrix  # [n_levels × 2]
+  run!(sim)
+  ```
+
 ## Returns
 An uninitialized `AuroraModel`. Call `initialize!(model)` or `run!(sim)` to complete setup.
 """
-function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0)
+function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith=0;
+                     species = (N2Species(msis_file), O2Species(msis_file), OSpecies(msis_file)))
     altitude_grid    = AltitudeGrid(altitude_lims[1], altitude_lims[2])
     energy_grid      = EnergyGrid(E_max)
     pitch_angle_grid = PitchAngleGrid(θ_lims)
     ionosphere       = Ionosphere(msis_file, iri_file, altitude_grid.h)
-    species          = (N2Species(msis_file), O2Species(msis_file), OSpecies(msis_file))
+    species_tuple    = Tuple(species)
     s_field          = altitude_grid.h ./ cosd(B_angle_to_zenith)
 
     FT = promote_type(eltype(s_field), typeof(B_angle_to_zenith))
 
     return AuroraModel{typeof(altitude_grid), typeof(energy_grid), typeof(pitch_angle_grid),
-                       typeof(ionosphere), typeof(species),
+                       typeof(ionosphere), typeof(species_tuple),
                        FT, typeof(s_field)}(
         altitude_grid, energy_grid, pitch_angle_grid,
-        nothing, ionosphere, species,
+        nothing, ionosphere, species_tuple,
         FT(B_angle_to_zenith), s_field, false
     )
 end
@@ -90,8 +104,12 @@ function initialize!(model::AuroraModel;
         sp.density           = collect(Float64, sp.density_profile(h))
         apply_density_boundary!(sp.density)
         name_str             = String(sp.name)
-        sp.cross_sections    = get_cross_section(name_str, eg.E_centers)
-        sp.excitation_levels = load_excitation_threshold_for(name_str)
+        if isempty(sp.cross_sections)
+            sp.cross_sections    = get_cross_section(name_str, eg.E_centers)
+        end
+        if isempty(sp.excitation_levels)
+            sp.excitation_levels = load_excitation_threshold_for(name_str)
+        end
         sp.phase_fcn         = sp.phase_fcn_generator(θ, eg.E_centers)
         load_or_compute_cascading!(sp.cascading_data, eg; verbose, policy)
     end
@@ -99,16 +117,6 @@ function initialize!(model::AuroraModel;
     return nothing
 end
 
-"""
-    n_neutrals(model::AuroraModel)
-
-Return neutral densities as a NamedTuple `(; nN2, nO2, nO)` sourced from the model's species.
-"""
-n_neutrals(model::AuroraModel) = (;
-    nN2 = model.species[1].density,
-    nO2 = model.species[2].density,
-    nO  = model.species[3].density,
-)
 
 function Base.show(io::IO, model::AuroraModel)
     print(io, "AuroraModel($(model.altitude_grid), $(model.energy_grid), $(model.pitch_angle_grid))")

--- a/src/model.jl
+++ b/src/model.jl
@@ -6,6 +6,14 @@ Container for the grids, atmosphere, and collision data used by an AURORA simula
 Construct cheaply with `AuroraModel(...)`, then call `initialize!(model)` (or `run!(sim)`)
 to perform the heavy setup: scattering matrices, species densities, cross sections, and
 cascading transfer matrices.
+
+The grid fields `altitude_grid` and `energy_grid` can be reassigned on an existing model.
+Call `initialize!(model)` afterwards to rebuild all derived data for the new grid:
+```julia
+model.altitude_grid = AltitudeGrid(80, 500)
+initialize!(model)     # recomputes s_field, ionosphere, species data
+initialize!(sim)       # rebuilds simulation cache arrays for the new grid dimensions
+```
 """
 mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
                             IO<:Ionosphere,
@@ -83,17 +91,27 @@ end
 """
     initialize!(model::AuroraModel; verbose=true, policy=CachePolicy())
 
-Perform all heavy one-time setup for `model`:
-1. Compute (or load from cache) the scattering matrices.
-2. For each species: sample the density profile, load cross sections and excitation levels,
-   build phase function matrices, and load/compute cascading transfer matrices.
+Perform all heavy setup for `model`.
+Always rebuilds from the current grid fields, so it can (and should) be called after
+reassigning `model.altitude_grid` or `model.energy_grid`.
+It does the following:
+1. Recompute `s_field` and `ionosphere` from the current altitude grid.
+2. Compute (or load from cache) the scattering matrices.
+3. For each species: sample the density profile, load cross sections and excitation levels
+   (skipped if already pre-populated), build phase functions, and load/compute cascading
+   transfer matrices.
 
 Called automatically by `initialize!(sim)` → `run!(sim)`. Call it directly when you need
-access to `model.scattering` or `model.species[i].density` before constructing a simulation.
+access to `model.scattering` or `model.species[i].density` before constructing a simulation,
+or after changing a grid field.
 """
 function initialize!(model::AuroraModel;
                      verbose::Bool = true,
                      policy::CachePolicy = CachePolicy())
+    model.s_field    = model.altitude_grid.h ./ cosd(model.B_angle_to_zenith)
+    model.ionosphere = Ionosphere(model.ionosphere.msis_file,
+                                  model.ionosphere.iri_file,
+                                  model.altitude_grid.h)
     model.scattering = ScatteringData(model.pitch_angle_grid; verbose, policy)
 
     h  = model.altitude_grid.h

--- a/src/model.jl
+++ b/src/model.jl
@@ -7,13 +7,17 @@ Construct cheaply with `AuroraModel(...)`, then call `initialize!(model)` (or `r
 to perform the heavy setup: scattering matrices, species densities, cross sections, and
 cascading transfer matrices.
 
-The grid fields `altitude_grid` and `energy_grid` can be reassigned on an existing model.
-Call `initialize!(model)` afterwards to rebuild all derived data for the new grid:
+The grid fields (`altitude_grid`, `energy_grid`, `pitch_angle_grid`) and `B_angle_to_zenith`
+can be reassigned on an existing model. Doing so automatically marks the model as
+uninitialized, so the next `run!(sim)` rebuilds all derived data *and* the simulation cache
+for the new grid:
 ```julia
 model.altitude_grid = AltitudeGrid(80, 500)
-initialize!(model)     # recomputes s_field, ionosphere, species data
-initialize!(sim)       # rebuilds simulation cache arrays for the new grid dimensions
+run!(sim)              # detects the change, rebuilds model + cache, then solves
 ```
+You can still call `initialize!(model)` explicitly if you want the rebuilt data (scattering,
+densities, …) available before constructing a simulation. If you do that *after* a simulation
+already exists, follow it with `initialize!(sim)` (or just change the grid and call `run!`).
 """
 mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
                             IO<:Ionosphere,
@@ -88,6 +92,19 @@ function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle
     )
 end
 
+# Reassigning a grid or the B-field geometry invalidates every derived quantity (scattering,
+# densities, cross sections, cascading, and any simulation cache built from this model). We
+# intercept those assignments to mark the model uninitialized, which lets `run!` /
+# `initialize!(sim)` detect the change and rebuild automatically.
+function Base.setproperty!(model::AuroraModel, name::Symbol, value)
+    ty = fieldtype(typeof(model), name)
+    setfield!(model, name, value isa ty ? value : convert(ty, value))
+    if name in (:altitude_grid, :energy_grid, :pitch_angle_grid, :B_angle_to_zenith)
+        setfield!(model, :initialized, false)
+    end
+    return value
+end
+
 """
     initialize!(model::AuroraModel; verbose=true, policy=CachePolicy())
 
@@ -122,9 +139,13 @@ function initialize!(model::AuroraModel;
         sp.density           = collect(Float64, sp.density_profile(h))
         apply_density_boundary!(sp.density)
         name_str             = String(sp.name)
-        if isempty(sp.cross_sections)
+        # Cross sections depend on the energy grid, so (re)load them whenever they are missing
+        # or sized for a different grid. This keeps them correct after an energy-grid swap,
+        # while leaving user-supplied cross sections that already match the current grid intact.
+        if isempty(sp.cross_sections) || size(sp.cross_sections, 2) != length(eg.E_centers)
             sp.cross_sections    = get_cross_section(name_str, eg.E_centers)
         end
+        # Excitation levels are independent of the energy grid; load once if not supplied.
         if isempty(sp.excitation_levels)
             sp.excitation_levels = load_excitation_threshold_for(name_str)
         end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,5 +1,5 @@
 """
-    AuroraModel{AG, EG, PAG, IO, SP, FT, V}
+    AuroraModel{AG, EG, PAG, SD, IO, SP, FT, V}
 
 Container for the grids, atmosphere, and collision data used by an AURORA simulation.
 
@@ -20,13 +20,13 @@ densities, …) available before constructing a simulation. If you do that *afte
 already exists, follow it with `initialize!(sim)` (or just change the grid and call `run!`).
 """
 mutable struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
-                            IO<:Ionosphere,
+                            SD<:ScatteringData, IO<:Ionosphere,
                             SP<:Tuple{Vararg{NeutralSpecies}},
                             FT, V<:AbstractVector{FT}}
     altitude_grid::AG
     energy_grid::EG
     pitch_angle_grid::PAG
-    scattering::Union{Nothing, ScatteringData}   # nothing until initialize!(model)
+    scattering::SD
     ionosphere::IO
     species::SP
     B_angle_to_zenith::FT
@@ -79,15 +79,16 @@ function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle
     pitch_angle_grid = PitchAngleGrid(θ_lims)
     ionosphere       = Ionosphere(msis_file, iri_file, altitude_grid.h)
     species_tuple    = Tuple(species)
+    scattering       = ScatteringData()
     s_field          = altitude_grid.h ./ cosd(B_angle_to_zenith)
 
     FT = promote_type(eltype(s_field), typeof(B_angle_to_zenith))
 
     return AuroraModel{typeof(altitude_grid), typeof(energy_grid), typeof(pitch_angle_grid),
-                       typeof(ionosphere), typeof(species_tuple),
+                       typeof(scattering), typeof(ionosphere), typeof(species_tuple),
                        FT, typeof(s_field)}(
         altitude_grid, energy_grid, pitch_angle_grid,
-        nothing, ionosphere, species_tuple,
+        scattering, ionosphere, species_tuple,
         FT(B_angle_to_zenith), s_field, false
     )
 end
@@ -166,7 +167,7 @@ function Base.show(io::IO, ::MIME"text/plain", model::AuroraModel)
     println(io, "├── ", model.altitude_grid)
     println(io, "├── ", model.energy_grid)
     println(io, "├── ", model.pitch_angle_grid)
-    println(io, "├── ", isnothing(model.scattering) ? "ScatteringData: (not initialized)" : model.scattering)
+    println(io, "├── ", model.initialized ? model.scattering : "ScatteringData: (not initialized)")
     println(io, "├── ", model.ionosphere)
     println(io, "├── Species: ", join((String(sp.name) for sp in model.species), ", "))
     print(io, "└── B angle to zenith: $(model.B_angle_to_zenith)°")

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,10 +1,11 @@
 """
-    AuroraModel{AG, EG, PAG, SD, IO, CS, FT, V}
+    AuroraModel{AG, EG, PAG, SD, IO, CS, SP, FT, V}
 
 Container for the grids, atmosphere, and collision data used by an AURORA simulation.
 """
 struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
                    SD<:ScatteringData, IO<:Ionosphere, CS<:CrossSectionData,
+                   SP<:Tuple{Vararg{NeutralSpecies}},
                    FT, V<:AbstractVector{FT}}
     altitude_grid::AG
     energy_grid::EG
@@ -12,6 +13,7 @@ struct AuroraModel{AG<:AltitudeGrid, EG<:EnergyGrid, PAG<:PitchAngleGrid,
     scattering::SD
     ionosphere::IO
     cross_sections::CS
+    species::SP
     B_angle_to_zenith::FT
     s_field::V
 end
@@ -55,15 +57,21 @@ function AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle
     scattering = ScatteringData(pitch_angle_grid; verbose, policy=cache_policy)
     ionosphere = Ionosphere(msis_file, iri_file, altitude_grid.h)
     cross_sections = CrossSectionData(energy_grid)
+    species = (
+        N2Species(altitude_grid, energy_grid, scattering, msis_file),
+        O2Species(altitude_grid, energy_grid, scattering, msis_file),
+        OSpecies(altitude_grid, energy_grid, scattering, msis_file),
+    )
     s_field = altitude_grid.h ./ cosd(B_angle_to_zenith)
 
     FT = promote_type(eltype(s_field), typeof(B_angle_to_zenith))
 
     return AuroraModel{typeof(altitude_grid), typeof(energy_grid), typeof(pitch_angle_grid),
                        typeof(scattering), typeof(ionosphere), typeof(cross_sections),
+                       typeof(species),
                        FT, typeof(s_field)}(
         altitude_grid, energy_grid, pitch_angle_grid,
-        scattering, ionosphere, cross_sections,
+        scattering, ionosphere, cross_sections, species,
         FT(B_angle_to_zenith), s_field
     )
 end
@@ -80,5 +88,6 @@ function Base.show(io::IO, ::MIME"text/plain", model::AuroraModel)
     println(io, "├── ", model.scattering)
     println(io, "├── ", model.ionosphere)
     println(io, "├── ", model.cross_sections)
+    println(io, "├── Species: ", join((String(sp.name) for sp in model.species), ", "))
     print(io, "└── B angle to zenith: $(model.B_angle_to_zenith)°")
 end

--- a/src/physics/cascading.jl
+++ b/src/physics/cascading.jl
@@ -61,25 +61,6 @@ function SpeciesCascadingCache(spec::S) where {S<:CascadingSpec}
     return SpeciesCascadingCache{S}(spec, zeros(0, 0, 0), zeros(0, 0, 0), Float64[], Float64[])
 end
 
-# Somewhat temporary container to hold all our three species specific caches
-# TODO: To be removed when we have fully moved towards a fully modular setup with things
-# attached to species inside the model.
-struct CascadingCache{T<:Tuple}
-    species::T
-end
-
-# And its initialization constructor
-function CascadingCache()
-    return CascadingCache((
-        SpeciesCascadingCache(DefaultCascadingSpecN2()),
-        SpeciesCascadingCache(DefaultCascadingSpecO2()),
-        SpeciesCascadingCache(DefaultCascadingSpecO()),
-    ))
-end
-
-Base.getindex(cache::CascadingCache, index::Int) = cache.species[index]
-Base.length(cache::CascadingCache) = length(cache.species)
-Base.iterate(cache::CascadingCache, state...) = iterate(cache.species, state...)
 
 
 

--- a/src/physics/cascading_cache.jl
+++ b/src/physics/cascading_cache.jl
@@ -20,6 +20,7 @@ function load_or_compute_cascading!(cache::CascadingCache, energy_grid::EnergyGr
     return nothing
 end
 
+
 function load_or_compute_cascading!(cache::SpeciesCascadingCache, energy_grid::EnergyGrid;
                                     verbose::Bool = true,
                                     policy::CachePolicy = CachePolicy())

--- a/src/physics/cascading_cache.jl
+++ b/src/physics/cascading_cache.jl
@@ -3,24 +3,14 @@ using JLD2: jldopen, @load, @save
 
 
 """
-    load_or_compute_cascading!(cache, energy_grid; verbose=true, policy=CachePolicy())
+    load_or_compute_cascading!(cache::SpeciesCascadingCache, energy_grid; verbose=true, policy=CachePolicy())
 
-Populate the cascading cache for all neutral species.
+Populate the cascading transfer matrices for one neutral species.
 
-If compatible (i.e. same grid, same `version_AURORA`, etc) JLD2 cache files are found on
-disk, the matrices are loaded from there. If not, they are computed from scratch (and
-possibly saved to disk depending on `CachePolicy` options).
+If a compatible (same grid, same `version_AURORA`) JLD2 cache file is found on disk,
+matrices are loaded from there. Otherwise they are computed from scratch (and optionally
+saved to disk depending on `CachePolicy` options).
 """
-function load_or_compute_cascading!(cache::CascadingCache, energy_grid::EnergyGrid;
-                                    verbose::Bool = true,
-                                    policy::CachePolicy = CachePolicy())
-    for species_cache in cache
-        load_or_compute_cascading!(species_cache, energy_grid; verbose, policy)
-    end
-    return nothing
-end
-
-
 function load_or_compute_cascading!(cache::SpeciesCascadingCache, energy_grid::EnergyGrid;
                                     verbose::Bool = true,
                                     policy::CachePolicy = CachePolicy())

--- a/src/physics/cross_sections/cross_sections.jl
+++ b/src/physics/cross_sections/cross_sections.jl
@@ -1,22 +1,6 @@
 using DelimitedFiles: readdlm
 
 """
-    CrossSectionData{NT1<:NamedTuple, NT2<:NamedTuple}
-
-Collision cross-sections and excitation thresholds for all neutral species.
-"""
-struct CrossSectionData{NT1<:NamedTuple, NT2<:NamedTuple}  # More explicit
-    σ_neutrals::NT1
-    collision_levels::NT2
-end
-
-function CrossSectionData(energy_grid::EnergyGrid)
-    σ_neutrals = load_cross_sections(energy_grid)
-    collision_levels = load_excitation_threshold()
-    return CrossSectionData(σ_neutrals, collision_levels)
-end
-
-"""
     load_excitation_threshold()
 
 Load the excitation thresholds or energy levels of the different states (vibrational,
@@ -124,19 +108,3 @@ function get_level_names(species_name)
     return vec(state_name)
 end
 
-function Base.show(io::IO, cs::CrossSectionData)
-    nE = size(cs.σ_neutrals.σ_N2, 2)
-    print(io, "CrossSectionData($(nE) energies)")
-end
-
-function Base.show(io::IO, ::MIME"text/plain", cs::CrossSectionData)
-    nE = size(cs.σ_neutrals.σ_N2, 2)
-    n_levels_N2 = size(cs.collision_levels.N2_levels, 1)
-    n_levels_O2 = size(cs.collision_levels.O2_levels, 1)
-    n_levels_O = size(cs.collision_levels.O_levels, 1)
-    println(io, "CrossSectionData:")
-    println(io, "├── Energy bins: $(nE)")
-    println(io, "├── N2 levels: $(n_levels_N2)")
-    println(io, "├── O2 levels: $(n_levels_O2)")
-    print(io, "└── O levels: $(n_levels_O)")
-end

--- a/src/physics/energy_degradation.jl
+++ b/src/physics/energy_degradation.jl
@@ -5,14 +5,11 @@ using LoopVectorization: @tturbo
 #################################################################################
 
 function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
-                   B2B_inelastic_neutrals, cascading_cache, iE, cache)
+                   B2B_inelastic_neutrals, iE, cache)
 
     z = model.altitude_grid.h
     ne = model.ionosphere.ne
     Te = model.ionosphere.Te
-    n_neutrals_data = n_neutrals(model.ionosphere)
-    σ_neutrals = model.cross_sections.σ_neutrals
-    collision_levels = model.cross_sections.collision_levels
     energy_grid = model.energy_grid
     E_edges = energy_grid.E_edges
     E_centers = energy_grid.E_centers
@@ -39,12 +36,12 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
     primary_e_spectrum   = cache.primary_e_spectrum
 
     # Loop over the neutral species
-    for i in 1:length(n_neutrals_data)
-        n = n_neutrals_data[i]                          # Neutral density
-        σ = σ_neutrals[i]                          # Array with collision cross sections
-        E_levels = collision_levels[i]            # Array with collision energy levels and number of secondary e-
-        B2B_inelastic = B2B_inelastic_neutrals[i]  # Array with the probabilities of scattering from beam to beam
-        species_cascading = cascading_cache[i]
+    for (i, sp) in enumerate(model.species)
+        n = sp.density
+        σ = sp.cross_sections
+        E_levels = sp.excitation_levels
+        B2B_inelastic = B2B_inelastic_neutrals[i]
+        species_cascading = sp.cascading_data
 
         add_inelastic_collisions!(Q, Ie, z, n, σ, E_levels, B2B_inelastic, energy_grid, iE, cache)
 

--- a/src/physics/scattering.jl
+++ b/src/physics/scattering.jl
@@ -28,8 +28,7 @@ function ScatteringData(grid::PitchAngleGrid;
 end
 
 # Empty placeholder held by an `AuroraModel` before `initialize!(model)` computes the real
-# matrices. It has the same concrete type as a real `ScatteringData` (all dense `Float64`
-# arrays), so `initialize!` can reassign the field in place without changing the model type.
+# matrices.
 ScatteringData() = ScatteringData(zeros(0, 0, 0), zeros(0, 0), Float64[], Float64[])
 
 function Base.show(io::IO, sd::ScatteringData)

--- a/src/physics/scattering.jl
+++ b/src/physics/scattering.jl
@@ -27,6 +27,11 @@ function ScatteringData(grid::PitchAngleGrid;
     )
 end
 
+# Empty placeholder held by an `AuroraModel` before `initialize!(model)` computes the real
+# matrices. It has the same concrete type as a real `ScatteringData` (all dense `Float64`
+# arrays), so `initialize!` can reassign the field in place without changing the model type.
+ScatteringData() = ScatteringData(zeros(0, 0, 0), zeros(0, 0), Float64[], Float64[])
+
 function Base.show(io::IO, sd::ScatteringData)
     n_beams = length(sd.Ω_beam)
     n_dir = length(sd.θ_scatter)

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -120,6 +120,18 @@ function NeutralSpecies(name::Symbol, density_profile;
     )
 end
 
+function Base.getindex(species::Tuple{Vararg{NeutralSpecies}}, name::Symbol)
+    found_index = 0
+    for (i, sp) in pairs(species)
+        if sp.name == name
+            found_index == 0 || throw(ArgumentError("Multiple species are named $(name)"))
+            found_index = i
+        end
+    end
+    found_index == 0 && throw(KeyError(name))
+    return species[found_index]
+end
+
 """
     apply_density_boundary!(n)
 

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -54,7 +54,7 @@ end
 # ======================================================================================== #
 
 """
-    NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+    NeutralSpecies{S<:CascadingSpec, C<:SpeciesCascadingCache, P}
 
 All per-species data needed to advance the transport equation through one neutral species.
 
@@ -62,17 +62,22 @@ All per-species data needed to advance the transport equation through one neutra
 - `name::Symbol`: short identifier (e.g. `:N2`, `:O2`, `:O`)
 - `density_profile`: callable `h_atm (m) → density (m⁻³)` used to (re)sample `density`.
     Can be an [`MSISDensity`](@ref), a [`VectorDensity`](@ref), or any callable.
-    This field is untyped so it can be replaced freely before calling `initialize!(model)`.
+    Untyped so it can be replaced freely before calling `initialize!(model)`.
 - `density::Vector{Float64}`: density profile sampled on the model altitude grid (m⁻³),
     with an erf-tail boundary applied at the top. Empty until `initialize!(model)` is called.
 - `cross_sections::Matrix{Float64}`: collision cross sections, shape `[n_levels × n_E]` (m²).
+    Auto-loaded from the built-in library when empty; pre-populate before `initialize!(model)`
+    to supply custom data for a non-standard species.
     Empty until `initialize!(model)` is called.
 - `excitation_levels::Matrix{Float64}`: excitation thresholds and secondary counts,
     shape `[n_levels × 2]`. First column = threshold energy (eV), second column = number
     of secondaries produced (non-zero only for ionizing channels).
+    Auto-loaded from the built-in library when empty; pre-populate before `initialize!(model)`
+    to supply custom data for a non-standard species.
     Empty until `initialize!(model)` is called.
-- `phase_fcn_generator::F`: callable `(θ, E) -> (phaseE, phaseI)` used to (re)build
-    `phase_fcn` whenever the pitch-angle or energy grid changes
+- `phase_fcn_generator`: callable `(θ, E) -> (phaseE, phaseI)` used to (re)build
+    `phase_fcn` whenever the pitch-angle or energy grid changes.
+    Untyped so it can be replaced freely before calling `initialize!(model)`.
 - `phase_fcn::P`: tuple `(phaseE, phaseI)` of `[n_θ × n_E]` matrices materialized from the
     generator on the model's scattering θ grid and energy centers.
     Holds 0×0 placeholder matrices until `initialize!(model)` is called.
@@ -81,13 +86,13 @@ All per-species data needed to advance the transport equation through one neutra
 - `cascading_data::C`: cascading transfer matrices (populated lazily by
     `load_or_compute_cascading!`)
 """
-mutable struct NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+mutable struct NeutralSpecies{S<:CascadingSpec, C<:SpeciesCascadingCache, P}
     name::Symbol
     density_profile        # untyped: freely replaceable before initialize!(model)
     density::Vector{Float64}
     cross_sections::Matrix{Float64}
     excitation_levels::Matrix{Float64}
-    phase_fcn_generator::F
+    phase_fcn_generator    # untyped: freely replaceable before initialize!(model)
     phase_fcn::P
     cascading_spec::S
     cascading_data::C

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -1,0 +1,153 @@
+using SpecialFunctions: erf
+
+"""
+    NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+
+All per-species data needed to advance the transport equation through one neutral species.
+
+# Fields
+- `name::Symbol`: short identifier (e.g. `:N2`, `:O2`, `:O`)
+- `density::Vector{Float64}`: density profile sampled on the model altitude grid (m⁻³)
+- `cross_sections::Matrix{Float64}`: collision cross sections, shape `[n_levels × n_E]` (m²)
+- `excitation_levels::Matrix{Float64}`: excitation thresholds and secondary counts,
+    shape `[n_levels × 2]`. First column = threshold energy (eV), second column = number
+    of secondaries produced (non-zero only for ionizing channels).
+- `phase_fcn_generator::F`: callable `(θ, E) -> (phaseE, phaseI)` used to (re)build
+    `phase_fcn` whenever the pitch-angle or energy grid changes
+- `phase_fcn::P`: tuple `(phaseE, phaseI)` of `[n_θ × n_E]` matrices materialized from the
+    generator on the model's scattering θ grid and energy centers
+- `cascading_spec::S`: ionization thresholds and secondary-distribution law used to
+    build the cascading transfer matrices
+- `cascading_data::C`: cascading transfer matrices (populated lazily by
+    `load_or_compute_cascading!`)
+"""
+mutable struct NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+    name::Symbol
+    density::Vector{Float64}
+    cross_sections::Matrix{Float64}
+    excitation_levels::Matrix{Float64}
+    phase_fcn_generator::F
+    phase_fcn::P
+    cascading_spec::S
+    cascading_data::C
+end
+
+"""
+    NeutralSpecies(name, density, energy_grid, scattering;
+                   cascading_spec, phase_fcn_generator)
+
+Build a `NeutralSpecies` from an already-sampled density vector. The density is copied
+and an upper-boundary erf-tail is applied in-place on the copy.
+
+The cross sections and excitation levels are loaded from
+`internal_data/data_neutrals/<name>_levels.{dat,name}` plus the `e_<name>_*` cross-section
+functions, looked up by `name`. The phase function matrices are materialized eagerly by
+calling `phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)`. The cascading
+data starts empty (matrices of size 0); it is populated by `load_or_compute_cascading!`.
+"""
+function NeutralSpecies(name::Symbol, density::AbstractVector,
+                        energy_grid::EnergyGrid, scattering::ScatteringData;
+                        cascading_spec::CascadingSpec,
+                        phase_fcn_generator)
+    density_processed = collect(Float64, density)
+    apply_density_boundary!(density_processed)
+
+    name_str = String(name)
+    cross_sections = get_cross_section(name_str, energy_grid.E_centers)
+    excitation_levels = load_excitation_threshold_for(name_str)
+
+    phase_fcn = phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)
+
+    cascading_data = SpeciesCascadingCache(cascading_spec)
+
+    return NeutralSpecies(name, density_processed, cross_sections, excitation_levels,
+                          phase_fcn_generator, phase_fcn, cascading_spec, cascading_data)
+end
+
+"""
+    apply_density_boundary!(n)
+
+Smoothly drive the top of a density profile to zero so the solver does not see a hard cut.
+The last 3 grid points are zeroed and the 3 points below are tapered by an error-function
+factor. Negative values (if any sneak in from log-space extrapolation) are clamped to 0.
+"""
+function apply_density_boundary!(n::AbstractVector)
+    n[end-2:end] .= 0
+    erf_factor = (erf.((1:-1:-1) / 2) .+ 1) / 2
+    n[end-5:end-3] .= erf_factor .* n[end-5:end-3]
+    if any(<(0), n)
+        @warn "Negative densities found. They were set to 0, but you might want to check " *
+              "why that happened"
+        n[n .< 0] .= 0
+    end
+    return n
+end
+
+# Per-species variant of load_excitation_threshold (which currently loads all three).
+function load_excitation_threshold_for(species_name::AbstractString)
+    file = pkgdir(AURORA, "internal_data", "data_neutrals", species_name * "_levels.dat")
+    return readdlm(file, comments=true, comment_char='%')
+end
+
+"""
+    N2Species(altitude_grid, energy_grid, scattering, msis_file)
+
+Construct the default N₂ species: density sampled from `msis_file`, cross sections from
+the built-in `e_N2_*` library, phase function from [`phase_fcn_N2`](@ref), and cascading
+described by [`DefaultCascadingSpecN2`](@ref).
+"""
+function N2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                   scattering::ScatteringData, msis_file::AbstractString)
+    density = load_msis_density(msis_file, :N2, altitude_grid.h)
+    return NeutralSpecies(:N2, density, energy_grid, scattering;
+                          cascading_spec = DefaultCascadingSpecN2(),
+                          phase_fcn_generator = phase_fcn_N2)
+end
+
+"""
+    O2Species(altitude_grid, energy_grid, scattering, msis_file)
+
+Default O₂ species, analogous to [`N2Species`](@ref).
+"""
+function O2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                   scattering::ScatteringData, msis_file::AbstractString)
+    density = load_msis_density(msis_file, :O2, altitude_grid.h)
+    return NeutralSpecies(:O2, density, energy_grid, scattering;
+                          cascading_spec = DefaultCascadingSpecO2(),
+                          phase_fcn_generator = phase_fcn_O2)
+end
+
+"""
+    OSpecies(altitude_grid, energy_grid, scattering, msis_file)
+
+Default O species, analogous to [`N2Species`](@ref).
+"""
+function OSpecies(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                  scattering::ScatteringData, msis_file::AbstractString)
+    density = load_msis_density(msis_file, :O, altitude_grid.h)
+    return NeutralSpecies(:O, density, energy_grid, scattering;
+                          cascading_spec = DefaultCascadingSpecO(),
+                          phase_fcn_generator = phase_fcn_O)
+end
+
+# Read MSIS file, interpolate to grid, return one species' density column.
+function load_msis_density(msis_file::AbstractString, species::Symbol, h_atm::AbstractVector)
+    msis_raw = load_msis(msis_file)
+    msis = interpolate_msis_to_grid(msis_raw.data, h_atm)
+    return getproperty(msis, species)
+end
+
+function Base.show(io::IO, sp::NeutralSpecies)
+    print(io, "NeutralSpecies($(sp.name), ", length(sp.density), " altitudes)")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
+    println(io, "NeutralSpecies(", sp.name, "):")
+    println(io, "├── Altitudes:        ", length(sp.density))
+    println(io, "├── Max density:      ", round(maximum(sp.density), sigdigits=3), " m⁻³")
+    println(io, "├── Cross sections:   ", size(sp.cross_sections, 1), " levels × ",
+                                          size(sp.cross_sections, 2), " energies")
+    println(io, "├── Excitation lvls:  ", size(sp.excitation_levels, 1))
+    print(io,   "└── Cascading:        ", sp.cascading_spec.name,
+                " (", length(sp.cascading_spec.ionization_thresholds), " thresholds)")
+end

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -54,32 +54,36 @@ end
 # ======================================================================================== #
 
 """
-    NeutralSpecies{D, F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+    NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
 
 All per-species data needed to advance the transport equation through one neutral species.
 
 # Fields
 - `name::Symbol`: short identifier (e.g. `:N2`, `:O2`, `:O`)
-- `density_profile::D`: callable `h_atm (m) → density (m⁻³)` used to (re)sample `density`.
+- `density_profile`: callable `h_atm (m) → density (m⁻³)` used to (re)sample `density`.
     Can be an [`MSISDensity`](@ref), a [`VectorDensity`](@ref), or any callable.
+    This field is untyped so it can be replaced freely before calling `initialize!(model)`.
 - `density::Vector{Float64}`: density profile sampled on the model altitude grid (m⁻³),
-    with an erf-tail boundary applied at the top
-- `cross_sections::Matrix{Float64}`: collision cross sections, shape `[n_levels × n_E]` (m²)
+    with an erf-tail boundary applied at the top. Empty until `initialize!(model)` is called.
+- `cross_sections::Matrix{Float64}`: collision cross sections, shape `[n_levels × n_E]` (m²).
+    Empty until `initialize!(model)` is called.
 - `excitation_levels::Matrix{Float64}`: excitation thresholds and secondary counts,
     shape `[n_levels × 2]`. First column = threshold energy (eV), second column = number
     of secondaries produced (non-zero only for ionizing channels).
+    Empty until `initialize!(model)` is called.
 - `phase_fcn_generator::F`: callable `(θ, E) -> (phaseE, phaseI)` used to (re)build
     `phase_fcn` whenever the pitch-angle or energy grid changes
 - `phase_fcn::P`: tuple `(phaseE, phaseI)` of `[n_θ × n_E]` matrices materialized from the
-    generator on the model's scattering θ grid and energy centers
+    generator on the model's scattering θ grid and energy centers.
+    Holds 0×0 placeholder matrices until `initialize!(model)` is called.
 - `cascading_spec::S`: ionization thresholds and secondary-distribution law used to
     build the cascading transfer matrices
 - `cascading_data::C`: cascading transfer matrices (populated lazily by
     `load_or_compute_cascading!`)
 """
-mutable struct NeutralSpecies{D, F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+mutable struct NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
     name::Symbol
-    density_profile::D
+    density_profile        # untyped: freely replaceable before initialize!(model)
     density::Vector{Float64}
     cross_sections::Matrix{Float64}
     excitation_levels::Matrix{Float64}
@@ -90,34 +94,25 @@ mutable struct NeutralSpecies{D, F, S<:CascadingSpec, C<:SpeciesCascadingCache, 
 end
 
 """
-    NeutralSpecies(name, density_profile, energy_grid, scattering, h_atm;
-                   cascading_spec, phase_fcn_generator)
+    NeutralSpecies(name, density_profile; cascading_spec, phase_fcn_generator)
 
-Build a `NeutralSpecies` by sampling `density_profile` on `h_atm`. An upper-boundary
-erf-tail is applied to the sampled vector.
-
-The cross sections and excitation levels are loaded from the built-in
-`internal_data/data_neutrals/<name>_levels.{dat,name}` files. The phase function matrices
-are materialized eagerly. The cascading data starts empty and is populated later by
-[`load_or_compute_cascading!`](@ref).
+Build a lightweight `NeutralSpecies`. All grid-dependent fields (`density`, `cross_sections`,
+`excitation_levels`, `phase_fcn`) start empty and are populated by `initialize!(model)`.
 """
-function NeutralSpecies(name::Symbol, density_profile,
-                        energy_grid::EnergyGrid, scattering::ScatteringData,
-                        h_atm::AbstractVector;
-                        cascading_spec::CascadingSpec,
-                        phase_fcn_generator)
-    density = collect(Float64, density_profile(h_atm))
-    apply_density_boundary!(density)
-
-    name_str = String(name)
-    cross_sections    = get_cross_section(name_str, energy_grid.E_centers)
-    excitation_levels = load_excitation_threshold_for(name_str)
-
-    phase_fcn    = phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)
-    cascading_data = SpeciesCascadingCache(cascading_spec)
-
-    return NeutralSpecies(name, density_profile, density, cross_sections, excitation_levels,
-                          phase_fcn_generator, phase_fcn, cascading_spec, cascading_data)
+function NeutralSpecies(name::Symbol, density_profile;
+                        cascading_spec::CascadingSpec, phase_fcn_generator)
+    empty_mat = Matrix{Float64}(undef, 0, 0)
+    return NeutralSpecies(
+        name,
+        density_profile,
+        Float64[],
+        empty_mat,
+        empty_mat,
+        phase_fcn_generator,
+        (empty_mat, copy(empty_mat)),
+        cascading_spec,
+        SpeciesCascadingCache(cascading_spec),
+    )
 end
 
 """
@@ -151,8 +146,8 @@ end
 # ======================================================================================== #
 
 """
-    N2Species(altitude_grid, energy_grid, scattering, density_profile)
-    N2Species(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
+    N2Species(density_profile)
+    N2Species(msis_file::AbstractString)
 
 Construct the default N₂ species with cross sections from the built-in `e_N2_*` library,
 phase function from [`phase_fcn_N2`](@ref), and cascading described by
@@ -160,49 +155,44 @@ phase function from [`phase_fcn_N2`](@ref), and cascading described by
 
 `density_profile` can be an [`MSISDensity`](@ref), a [`VectorDensity`](@ref), or any
 callable `h_atm (m) → density (m⁻³)`. Passing an MSIS file path string is a shorthand
-for `MSISDensity(msis_file, :N2)`.
+for `MSISDensity(msis_file, :N2)`. Grid-dependent fields are populated later by
+`initialize!(model)`.
 """
-function N2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                   scattering::ScatteringData, msis_file::AbstractString)
-    return N2Species(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :N2))
+function N2Species(msis_file::AbstractString)
+    return N2Species(MSISDensity(msis_file, :N2))
 end
-function N2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                   scattering::ScatteringData, density_profile)
-    return NeutralSpecies(:N2, density_profile, energy_grid, scattering, altitude_grid.h;
+function N2Species(density_profile)
+    return NeutralSpecies(:N2, density_profile;
                           cascading_spec      = DefaultCascadingSpecN2(),
                           phase_fcn_generator = phase_fcn_N2)
 end
 
 """
-    O2Species(altitude_grid, energy_grid, scattering, density_profile)
-    O2Species(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
+    O2Species(density_profile)
+    O2Species(msis_file::AbstractString)
 
 Default O₂ species, analogous to [`N2Species`](@ref).
 """
-function O2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                   scattering::ScatteringData, msis_file::AbstractString)
-    return O2Species(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :O2))
+function O2Species(msis_file::AbstractString)
+    return O2Species(MSISDensity(msis_file, :O2))
 end
-function O2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                   scattering::ScatteringData, density_profile)
-    return NeutralSpecies(:O2, density_profile, energy_grid, scattering, altitude_grid.h;
+function O2Species(density_profile)
+    return NeutralSpecies(:O2, density_profile;
                           cascading_spec      = DefaultCascadingSpecO2(),
                           phase_fcn_generator = phase_fcn_O2)
 end
 
 """
-    OSpecies(altitude_grid, energy_grid, scattering, density_profile)
-    OSpecies(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
+    OSpecies(density_profile)
+    OSpecies(msis_file::AbstractString)
 
 Default O species, analogous to [`N2Species`](@ref).
 """
-function OSpecies(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                  scattering::ScatteringData, msis_file::AbstractString)
-    return OSpecies(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :O))
+function OSpecies(msis_file::AbstractString)
+    return OSpecies(MSISDensity(msis_file, :O))
 end
-function OSpecies(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
-                  scattering::ScatteringData, density_profile)
-    return NeutralSpecies(:O, density_profile, energy_grid, scattering, altitude_grid.h;
+function OSpecies(density_profile)
+    return NeutralSpecies(:O, density_profile;
                           cascading_spec      = DefaultCascadingSpecO(),
                           phase_fcn_generator = phase_fcn_O)
 end
@@ -226,11 +216,15 @@ end
 function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
     println(io, "NeutralSpecies(", sp.name, "):")
     println(io, "├── Density profile: ", _profile_label(sp.density_profile))
-    println(io, "├── Altitudes:        ", length(sp.density))
-    println(io, "├── Max density:      ", round(maximum(sp.density), sigdigits=3), " m⁻³")
-    println(io, "├── Cross sections:   ", size(sp.cross_sections, 1), " levels × ",
-                                          size(sp.cross_sections, 2), " energies")
-    println(io, "├── Excitation lvls:  ", size(sp.excitation_levels, 1))
+    if isempty(sp.density)
+        println(io, "├── (not initialized — call initialize!(model))")
+    else
+        println(io, "├── Altitudes:        ", length(sp.density))
+        println(io, "├── Max density:      ", round(maximum(sp.density), sigdigits=3), " m⁻³")
+        println(io, "├── Cross sections:   ", size(sp.cross_sections, 1), " levels × ",
+                                              size(sp.cross_sections, 2), " energies")
+        println(io, "├── Excitation lvls:  ", size(sp.excitation_levels, 1))
+    end
     print(io,   "└── Cascading:        ", sp.cascading_spec.name,
                 " (", length(sp.cascading_spec.ionization_thresholds), " thresholds)")
 end

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -220,7 +220,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
     println(io, "NeutralSpecies(", sp.name, "):")
-    println(io, "├── Density profile: ", _profile_label(sp.density_profile))
+    println(io, "├── Density profile: ", profile_label(sp.density_profile))
     if isempty(sp.density)
         println(io, "├── (not initialized — call initialize!(model))")
     else
@@ -234,6 +234,6 @@ function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
                 " (", length(sp.cascading_spec.ionization_thresholds), " thresholds)")
 end
 
-_profile_label(d::MSISDensity)  = "MSISDensity($(basename(d.msis_file)), :$(d.species))"
-_profile_label(d::VectorDensity) = "VectorDensity($(length(d.h)) points)"
-_profile_label(d)               = string(typeof(d))
+profile_label(d::MSISDensity)  = "MSISDensity($(basename(d.msis_file)), :$(d.species))"
+profile_label(d::VectorDensity) = "VectorDensity($(length(d.h)) points)"
+profile_label(d)               = string(typeof(d))

--- a/src/physics/species.jl
+++ b/src/physics/species.jl
@@ -1,13 +1,69 @@
 using SpecialFunctions: erf
+using DataInterpolations: PCHIPInterpolation, ExtrapolationType
+
+# ======================================================================================== #
+#                              Density-profile types                                       #
+# ======================================================================================== #
 
 """
-    NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+    MSISDensity(msis_file, species)
+
+Density profile backed by an MSIS file. Callable on an altitude grid (m), returns the
+density vector (m⁻³) for the requested species (`:N2`, `:O2`, or `:O`).
+
+# Example
+```julia
+profile = MSISDensity(find_msis_file(), :N2)
+n = profile(altitude_grid.h)   # Vector{Float64}, length == length(altitude_grid.h)
+```
+"""
+struct MSISDensity
+    msis_file::String
+    species::Symbol
+end
+
+(d::MSISDensity)(h_atm::AbstractVector) = load_msis_density(d.msis_file, d.species, h_atm)
+
+"""
+    VectorDensity(h, n)
+
+Density profile defined by user-supplied altitude (`h`, m) and density (`n`, m⁻³) vectors.
+Callable on any altitude grid (m); evaluates via PCHIP interpolation in log-space,
+consistent with AURORA's MSIS interpolation convention.
+
+# Example
+```julia
+profile = VectorDensity(h_msis_m, n_N2)
+n = profile(altitude_grid.h)
+```
+"""
+struct VectorDensity
+    h::Vector{Float64}   # altitude (m)
+    n::Vector{Float64}   # density (m⁻³)
+end
+
+function (d::VectorDensity)(h_atm::AbstractVector)
+    itp = PCHIPInterpolation(log.(d.n), d.h ./ 1e3;
+                             extrapolation = ExtrapolationType.Linear)
+    return exp.(itp(collect(Float64, h_atm) ./ 1e3))
+end
+
+
+# ======================================================================================== #
+#                              NeutralSpecies                                              #
+# ======================================================================================== #
+
+"""
+    NeutralSpecies{D, F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
 
 All per-species data needed to advance the transport equation through one neutral species.
 
 # Fields
 - `name::Symbol`: short identifier (e.g. `:N2`, `:O2`, `:O`)
-- `density::Vector{Float64}`: density profile sampled on the model altitude grid (m⁻³)
+- `density_profile::D`: callable `h_atm (m) → density (m⁻³)` used to (re)sample `density`.
+    Can be an [`MSISDensity`](@ref), a [`VectorDensity`](@ref), or any callable.
+- `density::Vector{Float64}`: density profile sampled on the model altitude grid (m⁻³),
+    with an erf-tail boundary applied at the top
 - `cross_sections::Matrix{Float64}`: collision cross sections, shape `[n_levels × n_E]` (m²)
 - `excitation_levels::Matrix{Float64}`: excitation thresholds and secondary counts,
     shape `[n_levels × 2]`. First column = threshold energy (eV), second column = number
@@ -21,8 +77,9 @@ All per-species data needed to advance the transport equation through one neutra
 - `cascading_data::C`: cascading transfer matrices (populated lazily by
     `load_or_compute_cascading!`)
 """
-mutable struct NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
+mutable struct NeutralSpecies{D, F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
     name::Symbol
+    density_profile::D
     density::Vector{Float64}
     cross_sections::Matrix{Float64}
     excitation_levels::Matrix{Float64}
@@ -33,34 +90,33 @@ mutable struct NeutralSpecies{F, S<:CascadingSpec, C<:SpeciesCascadingCache, P}
 end
 
 """
-    NeutralSpecies(name, density, energy_grid, scattering;
+    NeutralSpecies(name, density_profile, energy_grid, scattering, h_atm;
                    cascading_spec, phase_fcn_generator)
 
-Build a `NeutralSpecies` from an already-sampled density vector. The density is copied
-and an upper-boundary erf-tail is applied in-place on the copy.
+Build a `NeutralSpecies` by sampling `density_profile` on `h_atm`. An upper-boundary
+erf-tail is applied to the sampled vector.
 
-The cross sections and excitation levels are loaded from
-`internal_data/data_neutrals/<name>_levels.{dat,name}` plus the `e_<name>_*` cross-section
-functions, looked up by `name`. The phase function matrices are materialized eagerly by
-calling `phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)`. The cascading
-data starts empty (matrices of size 0); it is populated by `load_or_compute_cascading!`.
+The cross sections and excitation levels are loaded from the built-in
+`internal_data/data_neutrals/<name>_levels.{dat,name}` files. The phase function matrices
+are materialized eagerly. The cascading data starts empty and is populated later by
+[`load_or_compute_cascading!`](@ref).
 """
-function NeutralSpecies(name::Symbol, density::AbstractVector,
-                        energy_grid::EnergyGrid, scattering::ScatteringData;
+function NeutralSpecies(name::Symbol, density_profile,
+                        energy_grid::EnergyGrid, scattering::ScatteringData,
+                        h_atm::AbstractVector;
                         cascading_spec::CascadingSpec,
                         phase_fcn_generator)
-    density_processed = collect(Float64, density)
-    apply_density_boundary!(density_processed)
+    density = collect(Float64, density_profile(h_atm))
+    apply_density_boundary!(density)
 
     name_str = String(name)
-    cross_sections = get_cross_section(name_str, energy_grid.E_centers)
+    cross_sections    = get_cross_section(name_str, energy_grid.E_centers)
     excitation_levels = load_excitation_threshold_for(name_str)
 
-    phase_fcn = phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)
-
+    phase_fcn    = phase_fcn_generator(scattering.θ_scatter, energy_grid.E_centers)
     cascading_data = SpeciesCascadingCache(cascading_spec)
 
-    return NeutralSpecies(name, density_processed, cross_sections, excitation_levels,
+    return NeutralSpecies(name, density_profile, density, cross_sections, excitation_levels,
                           phase_fcn_generator, phase_fcn, cascading_spec, cascading_data)
 end
 
@@ -83,50 +139,71 @@ function apply_density_boundary!(n::AbstractVector)
     return n
 end
 
-# Per-species variant of load_excitation_threshold (which currently loads all three).
+# Per-species variant of load_excitation_threshold (which loads all three species).
 function load_excitation_threshold_for(species_name::AbstractString)
     file = pkgdir(AURORA, "internal_data", "data_neutrals", species_name * "_levels.dat")
     return readdlm(file, comments=true, comment_char='%')
 end
 
-"""
-    N2Species(altitude_grid, energy_grid, scattering, msis_file)
 
-Construct the default N₂ species: density sampled from `msis_file`, cross sections from
-the built-in `e_N2_*` library, phase function from [`phase_fcn_N2`](@ref), and cascading
-described by [`DefaultCascadingSpecN2`](@ref).
+# ======================================================================================== #
+#                        Default species convenience constructors                          #
+# ======================================================================================== #
+
+"""
+    N2Species(altitude_grid, energy_grid, scattering, density_profile)
+    N2Species(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
+
+Construct the default N₂ species with cross sections from the built-in `e_N2_*` library,
+phase function from [`phase_fcn_N2`](@ref), and cascading described by
+[`DefaultCascadingSpecN2`](@ref).
+
+`density_profile` can be an [`MSISDensity`](@ref), a [`VectorDensity`](@ref), or any
+callable `h_atm (m) → density (m⁻³)`. Passing an MSIS file path string is a shorthand
+for `MSISDensity(msis_file, :N2)`.
 """
 function N2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
                    scattering::ScatteringData, msis_file::AbstractString)
-    density = load_msis_density(msis_file, :N2, altitude_grid.h)
-    return NeutralSpecies(:N2, density, energy_grid, scattering;
-                          cascading_spec = DefaultCascadingSpecN2(),
+    return N2Species(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :N2))
+end
+function N2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                   scattering::ScatteringData, density_profile)
+    return NeutralSpecies(:N2, density_profile, energy_grid, scattering, altitude_grid.h;
+                          cascading_spec      = DefaultCascadingSpecN2(),
                           phase_fcn_generator = phase_fcn_N2)
 end
 
 """
-    O2Species(altitude_grid, energy_grid, scattering, msis_file)
+    O2Species(altitude_grid, energy_grid, scattering, density_profile)
+    O2Species(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
 
 Default O₂ species, analogous to [`N2Species`](@ref).
 """
 function O2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
                    scattering::ScatteringData, msis_file::AbstractString)
-    density = load_msis_density(msis_file, :O2, altitude_grid.h)
-    return NeutralSpecies(:O2, density, energy_grid, scattering;
-                          cascading_spec = DefaultCascadingSpecO2(),
+    return O2Species(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :O2))
+end
+function O2Species(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                   scattering::ScatteringData, density_profile)
+    return NeutralSpecies(:O2, density_profile, energy_grid, scattering, altitude_grid.h;
+                          cascading_spec      = DefaultCascadingSpecO2(),
                           phase_fcn_generator = phase_fcn_O2)
 end
 
 """
-    OSpecies(altitude_grid, energy_grid, scattering, msis_file)
+    OSpecies(altitude_grid, energy_grid, scattering, density_profile)
+    OSpecies(altitude_grid, energy_grid, scattering, msis_file::AbstractString)
 
 Default O species, analogous to [`N2Species`](@ref).
 """
 function OSpecies(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
                   scattering::ScatteringData, msis_file::AbstractString)
-    density = load_msis_density(msis_file, :O, altitude_grid.h)
-    return NeutralSpecies(:O, density, energy_grid, scattering;
-                          cascading_spec = DefaultCascadingSpecO(),
+    return OSpecies(altitude_grid, energy_grid, scattering, MSISDensity(msis_file, :O))
+end
+function OSpecies(altitude_grid::AltitudeGrid, energy_grid::EnergyGrid,
+                  scattering::ScatteringData, density_profile)
+    return NeutralSpecies(:O, density_profile, energy_grid, scattering, altitude_grid.h;
+                          cascading_spec      = DefaultCascadingSpecO(),
                           phase_fcn_generator = phase_fcn_O)
 end
 
@@ -137,12 +214,18 @@ function load_msis_density(msis_file::AbstractString, species::Symbol, h_atm::Ab
     return getproperty(msis, species)
 end
 
+
+# ======================================================================================== #
+#                              Display                                                     #
+# ======================================================================================== #
+
 function Base.show(io::IO, sp::NeutralSpecies)
     print(io, "NeutralSpecies($(sp.name), ", length(sp.density), " altitudes)")
 end
 
 function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
     println(io, "NeutralSpecies(", sp.name, "):")
+    println(io, "├── Density profile: ", _profile_label(sp.density_profile))
     println(io, "├── Altitudes:        ", length(sp.density))
     println(io, "├── Max density:      ", round(maximum(sp.density), sigdigits=3), " m⁻³")
     println(io, "├── Cross sections:   ", size(sp.cross_sections, 1), " levels × ",
@@ -151,3 +234,7 @@ function Base.show(io::IO, ::MIME"text/plain", sp::NeutralSpecies)
     print(io,   "└── Cascading:        ", sp.cascading_spec.name,
                 " (", length(sp.cascading_spec.ionization_thresholds), " thresholds)")
 end
+
+_profile_label(d::MSISDensity)  = "MSISDensity($(basename(d.msis_file)), :$(d.species))"
+_profile_label(d::VectorDensity) = "VectorDensity($(length(d.h)) points)"
+_profile_label(d)               = string(typeof(d))

--- a/src/simulation/cache.jl
+++ b/src/simulation/cache.jl
@@ -62,16 +62,14 @@ function DegradationCache{N}(n_μ::Int, n_t::Int, n_z::Int, n_E::Int) where {N}
                             secondary_e_spectrum, primary_e_spectrum)
 end
 
-struct SimulationCache{D<:DegradationCache, C<:CascadingCache, TL, P, B}
+struct SimulationCache{D<:DegradationCache, TL, B}
     solver::SolverCache
     degradation::D
-    cascading::C
     matrices::TransportMatrices
     Ie::Array{Float64, 3}
     Ie_save::Array{Float64, 3}
     I0::Matrix{Float64}
     Ie_top::Array{Float64, 3}
     t_loop::TL
-    phase_fcn_neutrals::P
     B2B_fragment::B
 end

--- a/src/simulation/cache.jl
+++ b/src/simulation/cache.jl
@@ -34,18 +34,6 @@ mutable struct DegradationCache{N}
     primary_e_spectrum::NTuple{N, Vector{Float64}}   # energy spectrum weighting for primaries per species   (shape: n_E)
 end
 
-function DegradationCache()
-    ionization_source_sum = zeros(1, 1)
-    thermal_e_loss = zeros(1)
-    Ie_scatter = zeros(1, 1)
-    secondary_e_flux     = ntuple(_ -> zeros(1, 1), Val(3))
-    primary_e_flux       = ntuple(_ -> zeros(1, 1), Val(3))
-    secondary_e_spectrum = ntuple(_ -> zeros(1), Val(3))
-    primary_e_spectrum   = ntuple(_ -> zeros(1), Val(3))
-    return DegradationCache(ionization_source_sum, thermal_e_loss, Ie_scatter,
-                            secondary_e_flux, primary_e_flux,
-                            secondary_e_spectrum, primary_e_spectrum)
-end
 
 function DegradationCache{N}(n_μ::Int, n_t::Int, n_z::Int, n_E::Int) where {N}
     ionization_source_sum = Matrix{Float64}(undef, n_z, n_t)

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -27,8 +27,7 @@ function initialize!(sim::AuroraSimulation;
 end
 
 function build_dummy_simulation_cache(model::AuroraModel, time::AbstractTimeConfig)
-    neutral_densities = n_neutrals(model.ionosphere)
-    N_neutrals = length(neutral_densities)
+    N_neutrals = length(model.species)
     _, t_loop = get_time_parameters(time)
 
     solver = SolverCache()
@@ -60,8 +59,7 @@ function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy
     model = sim.model
     z = model.altitude_grid.h
     μ_center = model.pitch_angle_grid.μ_center
-    neutral_densities = n_neutrals(model.ionosphere)
-    N_neutrals = length(neutral_densities)
+    N_neutrals = length(model.species)
     n_E = model.energy_grid.n
 
     # Set up time grid dimensions for working arrays
@@ -85,6 +83,13 @@ function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy
     cascading = CascadingCache()
     # Pre-load/calculate the cascading transfer matrices.
     load_or_compute_cascading!(cascading, model.energy_grid; policy=cache_policy)
+    # Populate per-species cascading data from the loaded cache (commit 2 transition).
+    for (sp, species_cache) in zip(model.species, cascading)
+        sp.cascading_data.primary_transfer_matrix = species_cache.primary_transfer_matrix
+        sp.cascading_data.secondary_transfer_matrix = species_cache.secondary_transfer_matrix
+        sp.cascading_data.E_edges = species_cache.E_edges
+        sp.cascading_data.ionization_thresholds = species_cache.ionization_thresholds
+    end
 
     # Initialize solution arrays
     I0 = zeros(length(z) * length(μ_center), n_E)

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -26,10 +26,24 @@ function initialize!(sim::AuroraSimulation;
     if !sim.model.initialized
         initialize!(sim.model; verbose=true, policy=cache_policy)
     end
+    # Rebuild the time configuration from the (possibly changed) model grids. For
+    # TimeDependentMode the CFL-refined grid depends on the altitude and energy grids, so a
+    # grid swap since construction would otherwise leave sim.time (and the cache it sizes) stale.
+    sim.time = build_time_config(sim.model, sim.mode)
     sim.cache = build_simulation_cache(sim; cache_policy)
     sim.cache_initialized = true
     return nothing
 end
+
+"""
+    needs_initialization(sim::AuroraSimulation) -> Bool
+
+Return `true` when `sim` must be (re)initialized before solving: the cache was never built,
+or a grid was changed on the model (which marks it uninitialized via `setproperty!`).
+Used by [`run!`](@ref) to rebuild automatically.
+"""
+needs_initialization(sim::AuroraSimulation) =
+    !sim.cache_initialized || !sim.model.initialized
 
 function build_dummy_simulation_cache(model::AuroraModel, time::AbstractTimeConfig)
     N_neutrals = length(model.species)

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -32,26 +32,17 @@ function build_dummy_simulation_cache(model::AuroraModel, time::AbstractTimeConf
 
     solver = SolverCache()
     degradation = DegradationCache{N_neutrals}(1, 1, 1, 1)
-    cascading = CascadingCache()
     matrices = TransportMatrices(1, 1, 1, 1)
     Ie = zeros(1, 1, 1)
     Ie_save = zeros(1, 1, 1)
     I0 = zeros(1, 1)
     Ie_top = zeros(1, 1, 1)
-    phase_fcn_neutrals = build_dummy_phase_functions(model)
     B2B_fragment = zeros(size(model.scattering.Ω_subbeam_relative, 1),
                          size(model.scattering.P_scatter, 2),
                          size(model.scattering.P_scatter, 3))
 
-    return SimulationCache(solver, degradation, cascading, matrices, Ie, Ie_save, I0,
-                           Ie_top, t_loop, phase_fcn_neutrals, B2B_fragment)
-end
-
-function build_dummy_phase_functions(model::AuroraModel)
-    n_theta = length(model.scattering.θ_scatter)
-    n_energy = model.energy_grid.n
-    empty_phase_pair() = (zeros(n_theta, n_energy), zeros(n_theta, n_energy))
-    return (empty_phase_pair(), empty_phase_pair(), empty_phase_pair())
+    return SimulationCache(solver, degradation, matrices, Ie, Ie_save, I0,
+                           Ie_top, t_loop, B2B_fragment)
 end
 
 function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy = CachePolicy())
@@ -72,23 +63,15 @@ function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy
     update_D!(matrices.D, model)
     update_Ddiffusion!(matrices.Ddiffusion, model)
 
-    # Pre-compute scattering
-    phase_fcn_neutrals = compute_phase_functions(model)
+    # Pre-compute beam-to-beam scattering fragment
     B2B_fragment = prepare_beams2beams(model.scattering.Ω_subbeam_relative, model.scattering.P_scatter)
 
     # Pre-compute input flux data
     Ie_top = compute_input_flux(sim)
 
-    # Build the cascading cache
-    cascading = CascadingCache()
-    # Pre-load/calculate the cascading transfer matrices.
-    load_or_compute_cascading!(cascading, model.energy_grid; policy=cache_policy)
-    # Populate per-species cascading data from the loaded cache (commit 2 transition).
-    for (sp, species_cache) in zip(model.species, cascading)
-        sp.cascading_data.primary_transfer_matrix = species_cache.primary_transfer_matrix
-        sp.cascading_data.secondary_transfer_matrix = species_cache.secondary_transfer_matrix
-        sp.cascading_data.E_edges = species_cache.E_edges
-        sp.cascading_data.ionization_thresholds = species_cache.ionization_thresholds
+    # Load or compute per-species cascading transfer matrices
+    for sp in model.species
+        load_or_compute_cascading!(sp.cascading_data, model.energy_grid; policy=cache_policy)
     end
 
     # Initialize solution arrays
@@ -97,8 +80,8 @@ function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy
     n_t_save = n_steps_to_save(sim, t_loop)
     Ie_save = zeros(length(z) * length(μ_center), n_t_save, n_E)
 
-    return SimulationCache(solver, degradation, cascading, matrices, Ie, Ie_save, I0,
-                           Ie_top, t_loop, phase_fcn_neutrals, B2B_fragment)
+    return SimulationCache(solver, degradation, matrices, Ie, Ie_save, I0,
+                           Ie_top, t_loop, B2B_fragment)
 end
 
 # Time parameters for working arrays: (n_t, t_loop)
@@ -129,19 +112,3 @@ n_steps_to_save(::SingleStepConfig, t_loop) = 1
 n_steps_to_save(time::UniformTimeGrid, t_loop) = time.n_steps
 # n_save_per_loop + 1 to include the boundary/I0 column at the start of each loop
 n_steps_to_save(time::RefinedTimeGrid, t_loop) = time.n_save_per_loop + 1
-
-# Compute phase functions for electron and ion scattering off neutral molecules (N2, O2, O).
-# These phase functions describe the angular distribution of particles after collisions.
-function compute_phase_functions(model::AuroraModel)
-    E_centers = model.energy_grid.E_centers
-    θ_scatter = model.scattering.θ_scatter
-
-    print("Calculating the phase functions...")
-    phaseN2e, phaseN2i = phase_fcn_N2(θ_scatter, E_centers)
-    phaseO2e, phaseO2i = phase_fcn_O2(θ_scatter, E_centers)
-    phaseOe, phaseOi = phase_fcn_O(θ_scatter, E_centers)
-    println(" done ✅")
-
-    phase_fcn_neutrals = ((phaseN2e, phaseN2i), (phaseO2e, phaseO2i), (phaseOe, phaseOi))
-    return phase_fcn_neutrals
-end

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -7,14 +7,9 @@
 
 Allocate or re-allocate the working cache for `sim`.
 
-If the model has not been initialized yet, `initialize!(model)` is called first (scattering
-matrices, species densities, cross sections, cascading data). This step performs the
-expensive setup that depends on the model geometry and the resolved time grid, but does not
-write any output files.
-
 # Keywords
 - `force_recompute`: ignore compatible on-disk cascading caches and rebuild them
-- `save_cache`: skip writing newly computed cascading caches when set to `false`
+- `save_cache`: if `false`, skip writing newly computed cascading caches to disk
 - `cache_root`: parent directory that contains the cascading and scattering cache folders
 """
 function initialize!(sim::AuroraSimulation;
@@ -26,24 +21,14 @@ function initialize!(sim::AuroraSimulation;
     if !sim.model.initialized
         initialize!(sim.model; verbose=true, policy=cache_policy)
     end
-    # Rebuild the time configuration from the (possibly changed) model grids. For
-    # TimeDependentMode the CFL-refined grid depends on the altitude and energy grids, so a
-    # grid swap since construction would otherwise leave sim.time (and the cache it sizes) stale.
+    # Rebuild the time configuration from the (possibly changed) model grids.
     sim.time = build_time_config(sim.model, sim.mode)
     sim.cache = build_simulation_cache(sim; cache_policy)
     sim.cache_initialized = true
     return nothing
 end
 
-"""
-    needs_initialization(sim::AuroraSimulation) -> Bool
-
-Return `true` when `sim` must be (re)initialized before solving: the cache was never built,
-or a grid was changed on the model (which marks it uninitialized via `setproperty!`).
-Used by [`run!`](@ref) to rebuild automatically.
-"""
-needs_initialization(sim::AuroraSimulation) =
-    !sim.cache_initialized || !sim.model.initialized
+needs_initialization(sim::AuroraSimulation) = !sim.cache_initialized || !sim.model.initialized
 
 function build_dummy_simulation_cache(model::AuroraModel, time::AbstractTimeConfig)
     N_neutrals = length(model.species)

--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -7,8 +7,10 @@
 
 Allocate or re-allocate the working cache for `sim`.
 
-This step performs the expensive setup that depends on the model geometry and the
-resolved time grid, but does not write any output files.
+If the model has not been initialized yet, `initialize!(model)` is called first (scattering
+matrices, species densities, cross sections, cascading data). This step performs the
+expensive setup that depends on the model geometry and the resolved time grid, but does not
+write any output files.
 
 # Keywords
 - `force_recompute`: ignore compatible on-disk cascading caches and rebuild them
@@ -21,6 +23,9 @@ function initialize!(sim::AuroraSimulation;
                      cache_root::String = default_cache_root())
     @info "Initializing simulation..."
     cache_policy = CachePolicy(; force_recompute, save_cache, cache_root)
+    if !sim.model.initialized
+        initialize!(sim.model; verbose=true, policy=cache_policy)
+    end
     sim.cache = build_simulation_cache(sim; cache_policy)
     sim.cache_initialized = true
     return nothing
@@ -37,9 +42,7 @@ function build_dummy_simulation_cache(model::AuroraModel, time::AbstractTimeConf
     Ie_save = zeros(1, 1, 1)
     I0 = zeros(1, 1)
     Ie_top = zeros(1, 1, 1)
-    B2B_fragment = zeros(size(model.scattering.Ω_subbeam_relative, 1),
-                         size(model.scattering.P_scatter, 2),
-                         size(model.scattering.P_scatter, 3))
+    B2B_fragment = zeros(1, 1, 1)
 
     return SimulationCache(solver, degradation, matrices, Ie, Ie_save, I0,
                            Ie_top, t_loop, B2B_fragment)
@@ -68,11 +71,6 @@ function build_simulation_cache(sim::AuroraSimulation; cache_policy::CachePolicy
 
     # Pre-compute input flux data
     Ie_top = compute_input_flux(sim)
-
-    # Load or compute per-species cascading transfer matrices
-    for sp in model.species
-        load_or_compute_cascading!(sp.cascading_data, model.energy_grid; policy=cache_policy)
-    end
 
     # Initialize solution arrays
     I0 = zeros(length(z) * length(μ_center), n_E)

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -16,7 +16,7 @@ run!(sim)
 ```
 """
 function run!(sim::AuroraSimulation)
-    if !sim.cache_initialized
+    if needs_initialization(sim)
         initialize!(sim)
     end
     if sim.save_input_flux

--- a/src/simulation/run.jl
+++ b/src/simulation/run.jl
@@ -150,9 +150,7 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, t_loop, progress::Pro
     # High-to-low ensures cascading sources are available when solving lower energies.
     for iE in n_E:-1:1
         # Update transport matrices with current energy's scattering geometry
-        B2B_inelastic_neutrals = update_matrices!(cache.matrices, model,
-                                                  cache.phase_fcn_neutrals, iE,
-                                                  cache.B2B_fragment)
+        B2B_inelastic_neutrals = update_matrices!(cache.matrices, model, iE, cache.B2B_fragment)
 
         # Solve transport equation for current energy
         solve_energy_step!(sim, sim.mode, iE, Ie_top_local, t_loop)
@@ -161,8 +159,7 @@ function energy_loop!(sim::AuroraSimulation, Ie_top_local, t_loop, progress::Pro
         # - inelastic scattering collisions → degradation → lower energies
         # - ionization collisions → cascading secondaries & degraded primaries
         update_Q!(cache.matrices, cache.Ie, model, cache.t_loop,
-                  B2B_inelastic_neutrals, cache.cascading,
-                  iE, cache.degradation)
+                  B2B_inelastic_neutrals, iE, cache.degradation)
 
         next!(progress)
     end

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -412,7 +412,7 @@ mutable struct AuroraSimulation{M<:AuroraModel, F<:InputFlux, S<:AbstractMode,
     const flux::F
     const mode::S
     const savedir::String
-    const time::T
+    time::T               # rebuilt by initialize!(sim) if a grid changed (CFL grid depends on it)
     const save_input_flux::Bool
     cache::C
     cache_initialized::Bool
@@ -421,16 +421,16 @@ end
 function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir;
                           mode::AbstractMode=SteadyStateMode(),
                           save_input_flux=true)
-    time = _build_time_config(model, mode)
+    time = build_time_config(model, mode)
     cache = build_dummy_simulation_cache(model, time)
     return AuroraSimulation(model, flux, mode, String(savedir), time, save_input_flux,
                             cache, false)
 end
 
 # Build the appropriate time configuration based on the mode
-_build_time_config(model::AuroraModel, mode::SteadyStateMode) =
+build_time_config(model::AuroraModel, mode::SteadyStateMode) =
     is_multi_step(mode) ? UniformTimeGrid(mode.duration, mode.dt) : SingleStepConfig()
-_build_time_config(model::AuroraModel, mode::TimeDependentMode) =
+build_time_config(model::AuroraModel, mode::TimeDependentMode) =
     RefinedTimeGrid(model, mode)
 
 function Base.show(io::IO, sim::AuroraSimulation)

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -258,7 +258,7 @@ struct RefinedTimeGrid{TI<:AbstractRange{Float64}, TS<:AbstractRange{Float64}} <
     dt::Float64          # save cadence requested by the user
     dt_internal::Float64 # internal step = dt / CFL_factor, exact by construction
     CFL_factor::Int
-    t::TI                # full internal time grid  (length = n_save * CFL_factor + 1)
+    t::TI                # full internal time grid   (length = n_save * CFL_factor + 1)
     t_save::TS           # coarse save grid          (length = n_save + 1)
     n_save::Int          # total number of save intervals = round(Int, duration / dt)
     n_loop::Int

--- a/src/solvers/matrix_building.jl
+++ b/src/solvers/matrix_building.jl
@@ -123,7 +123,6 @@ function update_A!(A, model::AuroraModel, iE)
 end
 
 function update_B!(B, model::AuroraModel, iE, B2B_fragment)
-    ionosphere = model.ionosphere
     energy_grid = model.energy_grid
     scattering = model.scattering
     ΔE = energy_grid.ΔE

--- a/src/solvers/matrix_building.jl
+++ b/src/solvers/matrix_building.jl
@@ -97,25 +97,22 @@ end
 
 function update_A!(A, model::AuroraModel, iE)
     ionosphere = model.ionosphere
-    cross_sections = model.cross_sections
     energy_grid = model.energy_grid
-    n_neutrals_data = n_neutrals(ionosphere)
-    σ_neutrals = cross_sections.σ_neutrals
     E_centers = energy_grid.E_centers
     ΔE = energy_grid.ΔE
 
     fill!(A, 0.0)
     # Loop over the neutral species
-    for i1 in 1:length(n_neutrals_data)
-        n = n_neutrals_data[i1];  # Neutral density
-        σ = σ_neutrals[i1];  # Array with collision cross sections
+    for sp in model.species
+        n = sp.density
+        σ = sp.cross_sections
 
         # add elastic collisions
         A .+= n .* σ[1, iE];
 
         # add inelastic and ionization collisions
-        for i2 in 2:size(σ, 1)      # Loop over the different collisions, because
-            A .+= n .* σ[i2, iE];  # they have different cross sections
+        for i2 in 2:size(σ, 1)
+            A .+= n .* σ[i2, iE];
         end
     end
 
@@ -125,27 +122,22 @@ function update_A!(A, model::AuroraModel, iE)
     return nothing
 end
 
-function update_B!(B, model::AuroraModel, phase_fcn_neutrals, iE, B2B_fragment)
+function update_B!(B, model::AuroraModel, iE, B2B_fragment)
     ionosphere = model.ionosphere
-    cross_sections = model.cross_sections
     energy_grid = model.energy_grid
     scattering = model.scattering
-    n_neutrals_data = n_neutrals(ionosphere)
-    σ_neutrals = cross_sections.σ_neutrals
-    collision_levels = cross_sections.collision_levels
     ΔE = energy_grid.ΔE
     finer_θ = scattering.θ_scatter
 
     # Zero out B in place
     fill!(B, 0.0)
-    B2B_inelastic_neutrals = Vector{Matrix{Float64}}(undef, length(n_neutrals_data));
+    B2B_inelastic_neutrals = Vector{Matrix{Float64}}(undef, length(model.species));
     # Loop over the neutral species
-    for i in 1:length(n_neutrals_data)
-        n = n_neutrals_data[i];                  # Neutral density
-        σ = σ_neutrals[i];                  # Array with collision cross sections
-        E_levels = collision_levels[i];    # Array with collision enery levels and number of secondary e-
-        phase_fcn = phase_fcn_neutrals[i];   # Tuple with two phase function arrays, the first for elastic collisions
-                                                    # and the second for inelastic collisions
+    for (i, sp) in enumerate(model.species)
+        n = sp.density
+        σ = sp.cross_sections
+        E_levels = sp.excitation_levels
+        phase_fcn = sp.phase_fcn
 
         # Convert to 3D the scattering probabilities that are in 1D
         phase_fcn_e = convert_phase_fcn_to_3D(phase_fcn[1][:, iE], finer_θ);
@@ -257,24 +249,22 @@ function update_Ddiffusion!(Ddiffusion, model::AuroraModel)
 end
 
 """
-    update_matrices!(matrices, model, phase_fcn_neutrals, iE, B2B_fragment)
+    update_matrices!(matrices, model, iE, B2B_fragment)
 
 Update the A and B matrices in place for a given energy level iE.
 
 # Arguments
 - `matrices::TransportMatrices`: Container to update
 - `model`: `AuroraModel` (grids + atmosphere + physics)
-- `phase_fcn_neutrals`: Phase functions for all species
 - `iE`: Current energy index
 - `B2B_fragment`: Pre-computed beam-to-beam fragments
 
 # Returns
 - `B2B_inelastic_neutrals`: Array of inelastic beam-to-beam matrices for cascading calculations
 """
-function update_matrices!(matrices::TransportMatrices, model::AuroraModel, phase_fcn_neutrals,
-                          iE, B2B_fragment)
+function update_matrices!(matrices::TransportMatrices, model::AuroraModel, iE, B2B_fragment)
     update_A!(matrices.A, model, iE)
-    return update_B!(matrices.B, model, phase_fcn_neutrals, iE, B2B_fragment)
+    return update_B!(matrices.B, model, iE, B2B_fragment)
 end
 
 

--- a/src/solvers/sparse_indexing.jl
+++ b/src/solvers/sparse_indexing.jl
@@ -98,17 +98,17 @@ Returns `Mlhs` or `(Mlhs, Mrhs)`.
 """
 function create_transport_sparsity_pattern(n_z, n_angle, μ, D, Ddiffusion; include_rhs::Bool = false)
     max_nnz = n_angle * n_angle * 3 * n_z
-    row_l, col_l, val_l = _alloc_coo(max_nnz)
-    row_r, col_r, val_r = include_rhs ? _alloc_coo(max_nnz) : (Int[], Int[], Float64[])
+    row_l, col_l, val_l = alloc_coo(max_nnz)
+    row_r, col_r, val_r = include_rhs ? alloc_coo(max_nnz) : (Int[], Int[], Float64[])
 
     for i1 in 1:n_angle
         for i2 in 1:n_angle
             if i1 != i2
-                _add_offdiagonal_block!(row_l, col_l, val_l, i1, i2, n_z)
-                include_rhs && _add_offdiagonal_block!(row_r, col_r, val_r, i1, i2, n_z)
+                add_offdiagonal_block!(row_l, col_l, val_l, i1, i2, n_z)
+                include_rhs && add_offdiagonal_block!(row_r, col_r, val_r, i1, i2, n_z)
             else
-                _add_diagonal_block_lhs!(row_l, col_l, val_l, i1, n_z, μ, D, Ddiffusion)
-                include_rhs && _add_diagonal_block_rhs!(row_r, col_r, val_r, i1, n_z, μ, D, Ddiffusion)
+                add_diagonal_block_lhs!(row_l, col_l, val_l, i1, n_z, μ, D, Ddiffusion)
+                include_rhs && add_diagonal_block_rhs!(row_r, col_r, val_r, i1, n_z, μ, D, Ddiffusion)
             end
         end
     end
@@ -122,14 +122,14 @@ function create_transport_sparsity_pattern(n_z, n_angle, μ, D, Ddiffusion; incl
     return Mlhs
 end
 
-function _alloc_coo(max_nnz)
+function alloc_coo(max_nnz)
     rows = Vector{Int}();  sizehint!(rows, max_nnz)
     cols = Vector{Int}();  sizehint!(cols, max_nnz)
     vals = Vector{Float64}(); sizehint!(vals, max_nnz)
     return rows, cols, vals
 end
 
-function _add_offdiagonal_block!(rows, cols, vals, i1, i2, n_z)
+function add_offdiagonal_block!(rows, cols, vals, i1, i2, n_z)
     offset_row = (i1 - 1) * n_z
     offset_col = (i2 - 1) * n_z
     for i in 2:(n_z - 1)
@@ -139,7 +139,7 @@ function _add_offdiagonal_block!(rows, cols, vals, i1, i2, n_z)
     end
 end
 
-function _add_diagonal_block_lhs!(rows, cols, vals, i1, n_z, μ, D, Ddiffusion)
+function add_diagonal_block_lhs!(rows, cols, vals, i1, n_z, μ, D, Ddiffusion)
     offset = (i1 - 1) * n_z
 
     # First row boundary condition
@@ -169,7 +169,7 @@ function _add_diagonal_block_lhs!(rows, cols, vals, i1, n_z, μ, D, Ddiffusion)
     end
 end
 
-function _add_diagonal_block_rhs!(rows, cols, vals, i1, n_z, μ, D, Ddiffusion)
+function add_diagonal_block_rhs!(rows, cols, vals, i1, n_z, μ, D, Ddiffusion)
     offset = (i1 - 1) * n_z
     # No boundary rows in Mrhs
 
@@ -227,13 +227,13 @@ function extract_nzval_indices(M::SparseMatrixCSC, n_z::Int, n_angle::Int)
 
             if i1 != i2
                 # Off-diagonal: only main diagonal entries
-                d = _collect_indices(nz_lookup, offset_row, offset_col, 0, n_z)
+                d = collect_indices(nz_lookup, offset_row, offset_col, 0, n_z)
                 indices[i1, i2] = BlockIndices(d, Int[], Int[], 0, 0, 0)
             else
                 offset = (i1 - 1) * n_z
-                d     = _collect_indices(nz_lookup, offset, offset,  0, n_z)
-                sup   = _collect_indices(nz_lookup, offset, offset, +1, n_z)
-                sub   = _collect_indices(nz_lookup, offset, offset, -1, n_z)
+                d     = collect_indices(nz_lookup, offset, offset,  0, n_z)
+                sup   = collect_indices(nz_lookup, offset, offset, +1, n_z)
+                sub   = collect_indices(nz_lookup, offset, offset, -1, n_z)
 
                 bc_first   = get(nz_lookup, (offset + 1,    offset + 1),        0)
                 bc_last    = get(nz_lookup, (offset + n_z,  offset + n_z),      0)
@@ -251,7 +251,7 @@ end
 Collect nzval indices for a given diagonal offset within the interior rows 2:(n_z-1).
 `offset` is 0 for main diagonal, +1 for super, -1 for sub.
 """
-function _collect_indices(nz_lookup, offset_row, offset_col, diag_offset, n_z)
+function collect_indices(nz_lookup, offset_row, offset_col, diag_offset, n_z)
     out = Int[]
     sizehint!(out, n_z - 2)
     for i in 2:(n_z - 1)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -123,7 +123,7 @@ function save_parameters(sim::AuroraSimulation)
         write(f, "B_angle_to_zenith = $(model.B_angle_to_zenith) \n")
         write(f, "\n")
         write(f, "mode = $mode \n")
-        _write_time_params(f, sim)
+        write_time_params(f, sim)
         write(f, "\n")
         write(f, "flux = $(sim.flux) \n")
         write(f, "\n")
@@ -132,9 +132,9 @@ function save_parameters(sim::AuroraSimulation)
     end
 end
 
-_write_time_params(f::IO, sim::AuroraSimulation) = _write_time_params(f, sim.time)
+write_time_params(f::IO, sim::AuroraSimulation) = write_time_params(f, sim.time)
 
-function _write_time_params(f::IO, time::RefinedTimeGrid)
+function write_time_params(f::IO, time::RefinedTimeGrid)
     write(f, "duration = $(time.duration) \n")
     write(f, "dt = $(time.dt) \n")
     write(f, "dt_internal = $(time.dt_internal) \n")
@@ -142,13 +142,13 @@ function _write_time_params(f::IO, time::RefinedTimeGrid)
     write(f, "n_loop = $(time.n_loop) \n")
     write(f, "CFL_factor = $(time.CFL_factor) \n")
 end
-function _write_time_params(f::IO, time::UniformTimeGrid)
+function write_time_params(f::IO, time::UniformTimeGrid)
     write(f, "duration = $(time.duration) \n")
     write(f, "dt = $(time.dt) \n")
     write(f, "n_steps = $(time.n_steps) \n")
     write(f, "t = $(time.t) \n")
 end
-function _write_time_params(f::IO, ::SingleStepConfig)
+function write_time_params(f::IO, ::SingleStepConfig)
     write(f, "duration = nothing \n")
     write(f, "dt = nothing \n")
 end
@@ -362,7 +362,7 @@ end
 ## ====================================================================================== ##
 
 """
-    _smooth_transition(x, x_start = 0.0, x_end = 1.0)
+    smooth_transition(x, x_start = 0.0, x_end = 1.0)
 
 Create a smooth transition from 0 to 1 over the interval `[x_start, x_end]` using a
 C∞-smooth (infinitely differentiable) function.
@@ -379,7 +379,7 @@ C∞-smooth (infinitely differentiable) function.
 # Returns
 - A value between 0 and 1 representing the smooth transition
 """
-function _smooth_transition(x, x_start = 0.0, x_end = 1.0)
+function smooth_transition(x, x_start = 0.0, x_end = 1.0)
     # If the interval has zero width, return step function
     if iszero(x_end - x_start)
         return x < x_start ? 0.0 : 1.0

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -166,7 +166,6 @@ function save_neutrals(sim::AuroraSimulation)
         end
         write(file, "ne", ionosphere.ne)
         write(file, "Te", ionosphere.Te)
-        write(file, "Tn", ionosphere.Tn)
     close(file)
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -156,13 +156,14 @@ end
 
 using MAT: matopen
 function save_neutrals(sim::AuroraSimulation)
-    ionosphere = sim.model.ionosphere
+    model = sim.model
+    ionosphere = model.ionosphere
     savefile = joinpath(sim.savedir, "neutral_atm.mat")
     file = matopen(savefile, "w")
-        write(file, "h_atm", sim.model.altitude_grid.h)
-        write(file, "nN2", n_neutrals(ionosphere).nN2)
-        write(file, "nO2", n_neutrals(ionosphere).nO2)
-        write(file, "nO", n_neutrals(ionosphere).nO)
+        write(file, "h_atm", model.altitude_grid.h)
+        for sp in model.species
+            write(file, "n" * String(sp.name), sp.density)
+        end
         write(file, "ne", ionosphere.ne)
         write(file, "Te", ionosphere.Te)
         write(file, "Tn", ionosphere.Tn)

--- a/test/atmosphere/test_atmosphere.jl
+++ b/test/atmosphere/test_atmosphere.jl
@@ -5,11 +5,10 @@
     iono = Ionosphere(msis_file, iri_file, z)
 
     @test iono isa Ionosphere
-    @test length(iono.Tn) == length(z)
     @test length(iono.Te) == length(z)
     @test length(iono.ne) == length(z)
 
-    for field in (iono.Tn, iono.Te, iono.ne)
+    for field in (iono.Te, iono.ne)
         @test !any(isnan.(field))
         @test !any(isinf.(field))
         @test !any(field .< 0)

--- a/test/atmosphere/test_atmosphere.jl
+++ b/test/atmosphere/test_atmosphere.jl
@@ -21,18 +21,16 @@ end
     z = make_altitude_grid(50, 800)
     msis_file = find_msis_file()
 
-    @test_nowarn n_neutrals, Tn = AURORA.load_neutral_densities(msis_file, z)
-
-    n_neutrals, Tn = AURORA.load_neutral_densities(msis_file, z)
-    for i in eachindex(n_neutrals)
-        @test !any(isnan.(n_neutrals[i]))
-        @test !any(isinf.(n_neutrals[i]))
-        @test !any(n_neutrals[i] .< 0)
+    # Production path: each species samples its MSIS density profile on the grid, then the
+    # top boundary is tapered to zero by apply_density_boundary! (as in initialize!(model)).
+    for species in (:N2, :O2, :O)
+        n = AURORA.load_msis_density(msis_file, species, z)
+        @test_nowarn AURORA.apply_density_boundary!(n)
+        @test !any(isnan.(n))
+        @test !any(isinf.(n))
+        @test !any(n .< 0)
+        @test all(iszero, n[end-2:end])   # tapered to zero at the top
     end
-
-    @test !any(isnan.(Tn))
-    @test !any(isinf.(Tn))
-    @test !any(Tn .< 0)
 end
 
 

--- a/test/atmosphere/test_atmosphere.jl
+++ b/test/atmosphere/test_atmosphere.jl
@@ -5,23 +5,15 @@
     iono = Ionosphere(msis_file, iri_file, z)
 
     @test iono isa Ionosphere
-    @test length(iono.nN2) == length(z)
-    @test length(iono.nO2) == length(z)
-    @test length(iono.nO) == length(z)
     @test length(iono.Tn) == length(z)
     @test length(iono.Te) == length(z)
     @test length(iono.ne) == length(z)
 
-    for field in (iono.nN2, iono.nO2, iono.nO, iono.Tn, iono.Te, iono.ne)
+    for field in (iono.Tn, iono.Te, iono.ne)
         @test !any(isnan.(field))
         @test !any(isinf.(field))
         @test !any(field .< 0)
     end
-
-    nn = AURORA.n_neutrals(iono)
-    @test nn.nN2 === iono.nN2
-    @test nn.nO2 === iono.nO2
-    @test nn.nO === iono.nO
 end
 
 

--- a/test/ext/test_plotting.jl
+++ b/test/ext/test_plotting.jl
@@ -70,6 +70,7 @@
         savedir = "fake_dir"  # won't be used since we're not running the sim
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+        initialize!(model)
         flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0); beams = 1:2)
         sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
 
@@ -112,6 +113,7 @@
         savedir = "fake_dir"  # won't be used since we're not running the sim
 
         model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file, B_angle_to_zenith)
+        initialize!(model)
         flux = InputFlux(FlatSpectrum(1.0; E_min = 50.0), SinusoidalFlickering(5.0); beams = 1:2)
         sim = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode(duration=0.04, dt=0.01))
         @test plot_input(sim) isa Figure

--- a/test/input/test_input.jl
+++ b/test/input/test_input.jl
@@ -173,11 +173,11 @@ end
     ## Setting parameters
     altitude_lims = [100, 600];     # (km) altitude limits of the ionosphere
     θ_lims = 180:-10:0              # (°) angle-limits for the electron beams
-    E_max = 100000;                 # (eV) upper limit to the energy grid
+    E_max = 10_000;                 # (eV) upper limit to the energy grid
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
-    initialize!(model)
+    initialize!(model; policy = CachePolicy(save_cache = false))
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -212,7 +212,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
-    initialize!(model)
+    initialize!(model; policy = CachePolicy(save_cache = false))
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -275,7 +275,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
-    initialize!(model)
+    initialize!(model; policy = CachePolicy(save_cache = false))
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -319,7 +319,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
-    initialize!(model)
+    initialize!(model; policy = CachePolicy(save_cache = false))
     E_centers = model.energy_grid.E_centers
 
     # Physical constants

--- a/test/input/test_input.jl
+++ b/test/input/test_input.jl
@@ -177,6 +177,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
+    initialize!(model)
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -211,6 +212,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
+    initialize!(model)
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -273,6 +275,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
+    initialize!(model)
     E_centers = model.energy_grid.E_centers
 
     # Physical constants
@@ -316,6 +319,7 @@ end
     msis_file = find_msis_file();
     iri_file = find_iri_file();
     model = AuroraModel(altitude_lims, θ_lims, E_max, msis_file, iri_file)
+    initialize!(model)
     E_centers = model.energy_grid.E_centers
 
     # Physical constants

--- a/test/physics/test_cascading_cache.jl
+++ b/test/physics/test_cascading_cache.jl
@@ -1,21 +1,20 @@
-@testitem "CascadingCache provides spectra accessors" begin
+@testitem "SpeciesCascadingCache provides spectra accessors" begin
     energy_grid = AURORA.EnergyGrid(100)
-    cache = AURORA.CascadingCache()
+    cache = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecN2())
 
     AURORA.load_or_compute_cascading!(cache, energy_grid)
-    i_primary = searchsortedlast(cache[1].E_edges, 40.0)
-    secondary = AURORA.secondary_spectrum(cache[1], i_primary, 15.581)
-    primary = AURORA.primary_spectrum(cache[1], i_primary, 15.581)
+    i_primary = searchsortedlast(cache.E_edges, 40.0)
+    secondary = AURORA.secondary_spectrum(cache, i_primary, 15.581)
+    primary = AURORA.primary_spectrum(cache, i_primary, 15.581)
 
-    @test length(cache) == 3
     @test length(secondary) == energy_grid.n
     @test length(primary) == energy_grid.n
     @test sum(secondary) > 0
     @test sum(primary) >= 0
-    @test !isempty(cache[1].E_edges)
-    @test !isempty(cache[1].ionization_thresholds)
-    @test size(cache[1].secondary_transfer_matrix, 1) == energy_grid.n
-    @test size(cache[1].secondary_transfer_matrix, 2) == energy_grid.n
+    @test !isempty(cache.E_edges)
+    @test !isempty(cache.ionization_thresholds)
+    @test size(cache.secondary_transfer_matrix, 1) == energy_grid.n
+    @test size(cache.secondary_transfer_matrix, 2) == energy_grid.n
 end
 
 @testitem "Cascading cache lifecycle" begin
@@ -37,43 +36,49 @@ end
     skip_save_policy = AURORA.CachePolicy(force_recompute=true, save_cache=false,
                                           cache_root=joinpath(cache_root, "skip_save"))
 
-    cache = AURORA.CascadingCache()
-    AURORA.load_or_compute_cascading!(cache, energy_grid; policy=save_policy)
+    n2_cache = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecN2())
+    o2_cache = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecO2())
+    o_cache  = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecO())
+    AURORA.load_or_compute_cascading!(n2_cache, energy_grid; policy=save_policy)
+    AURORA.load_or_compute_cascading!(o2_cache, energy_grid; policy=save_policy)
+    AURORA.load_or_compute_cascading!(o_cache,  energy_grid; policy=save_policy)
 
     n2_dir = joinpath(cache_root, "e_cascading", "N2")
     o2_dir = joinpath(cache_root, "e_cascading", "O2")
-    o_dir = joinpath(cache_root, "e_cascading", "O")
+    o_dir  = joinpath(cache_root, "e_cascading", "O")
     @test length(cache_files(n2_dir)) == 1
     @test length(cache_files(o2_dir)) == 1
-    @test length(cache_files(o_dir)) == 1
+    @test length(cache_files(o_dir))  == 1
 
-    loaded_cache = AURORA.CascadingCache()
+    loaded_cache = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecN2())
     AURORA.load_or_compute_cascading!(loaded_cache, energy_grid; policy=load_policy)
-    @test loaded_cache[1].E_edges == cache[1].E_edges
-    @test loaded_cache[1].ionization_thresholds == cache[1].ionization_thresholds
+    @test loaded_cache.E_edges == n2_cache.E_edges
+    @test loaded_cache.ionization_thresholds == n2_cache.ionization_thresholds
 
     n2_file = joinpath(n2_dir, only(cache_files(n2_dir)))
     payload = jldopen(n2_file, "r") do file
         (
-            Q_primary = file["Q_primary"],
+            Q_primary   = file["Q_primary"],
             Q_secondary = file["Q_secondary"],
-            E_edges = file["E_edges"],
+            E_edges     = file["E_edges"],
             E_ionizations = file["E_ionizations"],
         )
     end
     rm(n2_file; force=true)
     jldopen(n2_file, "w") do file
         file["version_AURORA"] = "0.0.0"
-        file["Q_primary"] = payload.Q_primary
-        file["Q_secondary"] = payload.Q_secondary
-        file["E_edges"] = payload.E_edges
-        file["E_ionizations"] = payload.E_ionizations
+        file["Q_primary"]      = payload.Q_primary
+        file["Q_secondary"]    = payload.Q_secondary
+        file["E_edges"]        = payload.E_edges
+        file["E_ionizations"]  = payload.E_ionizations
     end
 
-    AURORA.load_or_compute_cascading!(AURORA.CascadingCache(), energy_grid; policy=load_policy)
+    stale_cache = AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecN2())
+    AURORA.load_or_compute_cascading!(stale_cache, energy_grid; policy=load_policy)
     @test compatible_cache_count(n2_dir) >= 1
 
-    AURORA.load_or_compute_cascading!(AURORA.CascadingCache(), energy_grid; policy=skip_save_policy)
+    AURORA.load_or_compute_cascading!(AURORA.SpeciesCascadingCache(AURORA.DefaultCascadingSpecN2()),
+                                      energy_grid; policy=skip_save_policy)
     skip_n2_dir = joinpath(cache_root, "skip_save", "e_cascading", "N2")
     @test isempty(cache_files(skip_n2_dir))
 

--- a/test/physics/test_cascading_cache.jl
+++ b/test/physics/test_cascading_cache.jl
@@ -87,3 +87,55 @@ end
     @test isempty(cache_files(o2_dir))
     @test isempty(cache_files(o_dir))
 end
+
+@testitem "Custom CascadingSpec produces valid transfer matrices" begin
+    flat_law = (E_s, E_p) -> 1.0
+    custom_spec = AURORA.CascadingSpec("FlatTest", [15.0, 25.0], flat_law)
+    cache = AURORA.SpeciesCascadingCache(custom_spec)
+    energy_grid = AURORA.EnergyGrid(100)
+
+    AURORA.load_or_compute_cascading!(cache, energy_grid;
+                                      policy=AURORA.CachePolicy(save_cache=false))
+
+    n_E = energy_grid.n
+    @test !isempty(cache.E_edges)
+    @test length(cache.ionization_thresholds) == 2
+    @test size(cache.secondary_transfer_matrix, 1) == n_E
+    @test size(cache.secondary_transfer_matrix, 2) == n_E
+    @test size(cache.primary_transfer_matrix, 1)   == n_E
+    @test size(cache.primary_transfer_matrix, 2)   == n_E
+    @test all(cache.secondary_transfer_matrix .>= 0)
+    @test all(cache.primary_transfer_matrix   .>= 0)
+    # no secondary production below the lowest ionization threshold
+    i_threshold = searchsortedlast(cache.E_edges, 15.0)
+    @test all(cache.secondary_transfer_matrix[1:i_threshold, :, :] .== 0)
+end
+
+@testitem "Custom NeutralSpecies with custom CascadingSpec: spectra are accessible" begin
+    msis_file = find_msis_file()
+
+    custom_law  = (E_s, E_p) -> 1.0 / (11.4^2 + E_s^2)
+    custom_spec = AURORA.CascadingSpec("N2variant", [15.581, 16.73, 18.75], custom_law)
+
+    sp = AURORA.NeutralSpecies(:N2, AURORA.MSISDensity(msis_file, :N2);
+                               cascading_spec      = custom_spec,
+                               phase_fcn_generator = AURORA.phase_fcn_N2)
+
+    @test sp.cascading_spec.name == "N2variant"
+    @test isempty(sp.density)
+
+    energy_grid = AURORA.EnergyGrid(100)
+    AURORA.load_or_compute_cascading!(sp.cascading_data, energy_grid;
+                                      policy=AURORA.CachePolicy(save_cache=false))
+
+    n_E = energy_grid.n
+    i_primary = searchsortedlast(sp.cascading_data.E_edges, 40.0)
+    secondary = AURORA.secondary_spectrum(sp.cascading_data, i_primary, 15.581)
+    primary   = AURORA.primary_spectrum(sp.cascading_data,   i_primary, 15.581)
+
+    @test length(secondary) == n_E
+    @test length(primary)   == n_E
+    @test sum(secondary) >= 0
+    @test all(secondary .>= 0)
+    @test all(primary   .>= 0)
+end

--- a/test/physics/test_cross-section.jl
+++ b/test/physics/test_cross-section.jl
@@ -1,12 +1,19 @@
-@testitem "CrossSectionData construction" begin
+@testitem "Cross-section loading functions" begin
     energy_grid = AURORA.EnergyGrid(500)
-    cs = AURORA.CrossSectionData(energy_grid)
 
-    @test cs isa AURORA.CrossSectionData
-    @test size(cs.σ_neutrals.σ_N2, 2) == energy_grid.n
-    @test size(cs.σ_neutrals.σ_O2, 2) == energy_grid.n
-    @test size(cs.σ_neutrals.σ_O, 2) == energy_grid.n
-    @test size(cs.collision_levels.N2_levels, 2) == 2
-    @test size(cs.collision_levels.O2_levels, 2) == 2
-    @test size(cs.collision_levels.O_levels, 2) == 2
+    σ_N2 = AURORA.get_cross_section("N2", energy_grid.E_centers)
+    σ_O2 = AURORA.get_cross_section("O2", energy_grid.E_centers)
+    σ_O  = AURORA.get_cross_section("O",  energy_grid.E_centers)
+
+    @test size(σ_N2, 2) == energy_grid.n
+    @test size(σ_O2, 2) == energy_grid.n
+    @test size(σ_O,  2) == energy_grid.n
+
+    N2_levels = AURORA.load_excitation_threshold_for("N2")
+    O2_levels = AURORA.load_excitation_threshold_for("O2")
+    O_levels  = AURORA.load_excitation_threshold_for("O")
+
+    @test size(N2_levels, 2) == 2
+    @test size(O2_levels, 2) == 2
+    @test size(O_levels,  2) == 2
 end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -199,3 +199,73 @@ end
         @test n2_density[1] ≈ 1e18   # bottom of the grid, unaffected by boundary taper
     end
 end
+
+@testitem "AuroraModel with 2 species: run! succeeds" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0;
+                            species = (O2Species(msis_file), OSpecies(msis_file)))
+        flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim  = AuroraSimulation(model, flux, savedir; mode = SteadyStateMode())
+        run!(sim)
+
+        @test sim.model.initialized
+        @test length(sim.model.species) == 2
+        @test sim.cache.degradation.secondary_e_flux isa NTuple{2, Matrix{Float64}}
+    end
+end
+
+@testitem "Custom 4th species with pre-populated cross sections: run! succeeds" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        custom_law  = (E_s, E_p) -> 1.0 / (11.4^2 + E_s^2)
+        custom_spec = AURORA.CascadingSpec("CustomGas", [15.581, 16.73, 18.75], custom_law)
+        custom_sp   = AURORA.NeutralSpecies(:CustomGas, h -> fill(1e18, length(h));
+                                            cascading_spec      = custom_spec,
+                                            phase_fcn_generator = AURORA.phase_fcn_N2)
+
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0;
+                            species = (N2Species(msis_file), O2Species(msis_file),
+                                       OSpecies(msis_file), custom_sp))
+
+        # Interception window: pre-populate cross sections and excitation levels before
+        # initialize!(model) runs (name-based auto-lookup would fail for :CustomGas)
+        # We just reuse the N2 cross sections and levels here
+        eg = model.energy_grid
+        model.species[end].cross_sections    = AURORA.get_cross_section("N2", eg.E_centers)
+        model.species[end].excitation_levels = AURORA.load_excitation_threshold_for("N2")
+
+        flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim  = AuroraSimulation(model, flux, savedir; mode = SteadyStateMode())
+        run!(sim)
+
+        @test sim.model.initialized
+        @test length(sim.model.species) == 4
+        @test sim.cache.degradation.secondary_e_flux isa NTuple{4, Matrix{Float64}}
+        @test sim.model.species[end].name == :CustomGas
+        @test !isempty(sim.model.species[end].density)
+    end
+end
+
+@testitem "Custom phase function via interception window: run! succeeds" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+
+        custom_generator = (θ, E) -> AURORA.phase_fcn_N2(θ, E)
+        model.species[1].phase_fcn_generator = custom_generator
+
+        flux = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim  = AuroraSimulation(model, flux, savedir; mode = SteadyStateMode())
+        run!(sim)
+
+        @test sim.model.initialized
+        @test model.species[1].phase_fcn_generator === custom_generator
+    end
+end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -134,3 +134,34 @@ end
     @test time_dependent.duration == 0.04
     @test time_dependent.dt == 0.01
 end
+
+@testitem "NeutralSpecies density_profile types" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+
+    # Default model: all species backed by MSISDensity
+    for sp in model.species
+        @test sp.density_profile isa MSISDensity
+    end
+
+    # Build VectorDensity profiles from the MSIS-sampled densities and verify round-trip
+    ag = model.altitude_grid
+    eg = model.energy_grid
+    sc = model.scattering
+
+    n2_ref  = model.species[1]
+    raw_n2  = AURORA.load_msis_density(msis_file, :N2, ag.h)   # raw, no erf-tail
+    vd      = VectorDensity(ag.h, raw_n2)
+    sp_vd   = AURORA.N2Species(ag, eg, sc, vd)
+
+    @test sp_vd.density_profile isa VectorDensity
+    # PCHIP through the exact sample points reproduces the raw data, then apply_density_boundary!
+    # is applied — so the result must match the MSISDensity path to machine precision
+    @test sp_vd.density ≈ n2_ref.density rtol=1e-6
+
+    # Plain callable also accepted
+    flat_profile = h -> fill(1e15, length(h))
+    sp_fn = AURORA.N2Species(ag, eg, sc, flat_profile)
+    @test all(==(0.0), sp_fn.density[end-2:end])  # erf-tail applied
+end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -168,6 +168,26 @@ end
     @test isempty(sp_fn.density)
 end
 
+@testitem "AuroraModel species support Symbol indexing" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+
+    @test model.species[:N2] === model.species[1]
+    @test model.species[:O2] === model.species[2]
+    @test model.species[:O] === model.species[3]
+    @test_throws KeyError model.species[:NO]
+end
+
+@testitem "Species Symbol indexing rejects duplicate names" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0;
+                        species = (N2Species(msis_file), N2Species(msis_file)))
+
+    @test_throws ArgumentError model.species[:N2]
+end
+
 @testitem "AuroraModel is uninitialized before initialize!" begin
     msis_file = find_msis_file()
     iri_file  = find_iri_file()

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -269,3 +269,44 @@ end
         @test model.species[1].phase_fcn_generator === custom_generator
     end
 end
+
+@testitem "Altitude grid swap: initialize!(model) rebuilds s_field and ionosphere" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+    initialize!(model)
+    old_n_z = model.altitude_grid.n
+    @test length(model.s_field)               == old_n_z
+    @test length(model.ionosphere.Tn)         == old_n_z
+    @test length(model.species[1].density)    == old_n_z
+
+    model.altitude_grid = AltitudeGrid(100, 300)
+    initialize!(model)
+
+    new_n_z = model.altitude_grid.n
+    @test new_n_z > old_n_z
+    @test length(model.s_field)               == new_n_z
+    @test length(model.ionosphere.Tn)         == new_n_z
+    @test length(model.species[1].density)    == new_n_z
+end
+
+@testitem "Altitude grid swap: run! after initialize!(model) succeeds" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+        flux  = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim   = AuroraSimulation(model, flux, savedir; mode = SteadyStateMode())
+        run!(sim)
+
+        model.altitude_grid = AltitudeGrid(100, 300)
+        initialize!(model)   # recomputes s_field, ionosphere, species
+        initialize!(sim)     # rebuilds simulation cache for new grid dimensions
+        run!(sim)
+
+        @test sim.model.initialized
+        @test length(sim.model.s_field) == model.altitude_grid.n
+    end
+end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -299,7 +299,7 @@ end
     initialize!(model)
     old_n_z = model.altitude_grid.n
     @test length(model.s_field)               == old_n_z
-    @test length(model.ionosphere.Tn)         == old_n_z
+    @test length(model.ionosphere.ne)         == old_n_z
     @test length(model.species[1].density)    == old_n_z
 
     model.altitude_grid = AltitudeGrid(100, 300)
@@ -308,7 +308,7 @@ end
     new_n_z = model.altitude_grid.n
     @test new_n_z > old_n_z
     @test length(model.s_field)               == new_n_z
-    @test length(model.ionosphere.Tn)         == new_n_z
+    @test length(model.ionosphere.ne)         == new_n_z
     @test length(model.species[1].density)    == new_n_z
 end
 

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -174,7 +174,8 @@ end
     model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
 
     @test !model.initialized
-    @test isnothing(model.scattering)
+    @test model.scattering isa AURORA.ScatteringData
+    @test isempty(model.scattering.θ_scatter)
     @test isempty(model.species[1].density)
 end
 

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -310,3 +310,67 @@ end
         @test length(sim.model.s_field) == model.altitude_grid.n
     end
 end
+
+@testitem "Reassigning a grid invalidates the model" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+    initialize!(model)
+    @test model.initialized
+
+    # Each geometry reassignment must flip `initialized` back to false.
+    model.altitude_grid = AltitudeGrid(100, 300)
+    @test !model.initialized
+
+    initialize!(model)
+    model.energy_grid = EnergyGrid(200)
+    @test !model.initialized
+
+    initialize!(model)
+    model.B_angle_to_zenith = 20
+    @test !model.initialized
+end
+
+@testitem "Grid change then bare run! auto-reinitializes (no manual init)" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+        flux  = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim   = AuroraSimulation(model, flux, savedir; mode = SteadyStateMode())
+        run!(sim)
+
+        # Change the grid and call run! directly — no initialize!(model)/initialize!(sim).
+        model.altitude_grid = AltitudeGrid(100, 300)
+        run!(sim)
+
+        @test sim.model.initialized
+        @test length(sim.model.s_field)           == model.altitude_grid.n
+        @test size(sim.cache.Ie, 1) ÷ length(model.pitch_angle_grid.μ_center) == model.altitude_grid.n
+    end
+end
+
+@testitem "Energy grid change rebuilds sim.time and cache (TimeDependent)" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+
+        model = AuroraModel([100, 200], 180:-90:0, 80, msis_file, iri_file, 0)
+        flux  = InputFlux(FlatSpectrum(1e-2; E_min = 50.0); beams = 1:2)
+        sim   = AuroraSimulation(model, flux, savedir;
+                                 mode = TimeDependentMode(duration=0.02, dt=0.01,
+                                                          CFL_number=128, n_loop=1))
+        run!(sim)
+        @test size(sim.cache.Ie, 3) == model.energy_grid.n
+
+        # Larger energy grid → more energy bins AND a different CFL-refined time grid.
+        model.energy_grid = EnergyGrid(200)
+        run!(sim)
+
+        @test sim.model.initialized
+        @test size(sim.cache.Ie, 3) == model.energy_grid.n
+        @test sim.time isa AURORA.RefinedTimeGrid
+    end
+end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -23,6 +23,7 @@
         initialize!(sim)
 
         @test sim.cache_initialized
+        @test sim.model.initialized
         n_species = 3
         @test sim.cache.degradation.secondary_e_flux isa NTuple{n_species, Matrix{Float64}}
         @test sim.cache.degradation.primary_e_spectrum isa NTuple{n_species, Vector{Float64}}
@@ -140,28 +141,61 @@ end
     iri_file  = find_iri_file()
     model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
 
-    # Default model: all species backed by MSISDensity
+    # Default model: all species backed by MSISDensity; density is empty before initialize!
     for sp in model.species
         @test sp.density_profile isa MSISDensity
     end
+    @test isempty(model.species[1].density)
 
-    # Build VectorDensity profiles from the MSIS-sampled densities and verify round-trip
+    # After initialize! density is populated
+    initialize!(model)
     ag = model.altitude_grid
-    eg = model.energy_grid
-    sc = model.scattering
+    @test !isempty(model.species[1].density)
 
-    n2_ref  = model.species[1]
-    raw_n2  = AURORA.load_msis_density(msis_file, :N2, ag.h)   # raw, no erf-tail
-    vd      = VectorDensity(ag.h, raw_n2)
-    sp_vd   = AURORA.N2Species(ag, eg, sc, vd)
+    # VectorDensity round-trip: PCHIP through exact sample points → same density as MSISDensity
+    raw_n2 = AURORA.load_msis_density(msis_file, :N2, ag.h)
+    vd = VectorDensity(ag.h, raw_n2)
+    model_vd = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+    model_vd.species[1].density_profile = vd
+    initialize!(model_vd)
+    @test model_vd.species[1].density_profile isa VectorDensity
+    @test model_vd.species[1].density ≈ model.species[1].density rtol=1e-6
 
-    @test sp_vd.density_profile isa VectorDensity
-    # PCHIP through the exact sample points reproduces the raw data, then apply_density_boundary!
-    # is applied — so the result must match the MSISDensity path to machine precision
-    @test sp_vd.density ≈ n2_ref.density rtol=1e-6
-
-    # Plain callable also accepted
+    # Plain callable is also accepted as density_profile; density is empty until initialize!
     flat_profile = h -> fill(1e15, length(h))
-    sp_fn = AURORA.N2Species(ag, eg, sc, flat_profile)
-    @test all(==(0.0), sp_fn.density[end-2:end])  # erf-tail applied
+    sp_fn = AURORA.N2Species(flat_profile)
+    @test sp_fn.density_profile === flat_profile
+    @test isempty(sp_fn.density)
+end
+
+@testitem "AuroraModel is uninitialized before initialize!" begin
+    msis_file = find_msis_file()
+    iri_file  = find_iri_file()
+    model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+
+    @test !model.initialized
+    @test isnothing(model.scattering)
+    @test isempty(model.species[1].density)
+end
+
+@testitem "initialize!(model) interception window" begin
+    mktempdir() do savedir
+        msis_file = find_msis_file()
+        iri_file  = find_iri_file()
+        model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
+
+        flat_n2 = h -> fill(1e18, length(h))
+        model.species[1].density_profile = flat_n2
+
+        flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
+        sim  = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
+
+        @test !sim.model.initialized
+        run!(sim)
+        @test sim.model.initialized
+
+        n2_density = sim.model.species[1].density
+        @test !isempty(n2_density)
+        @test n2_density[1] ≈ 1e18   # bottom of the grid, unaffected by boundary taper
+    end
 end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -206,7 +206,7 @@ end
         model = AuroraModel([100, 200], 180:-90:0, 100, msis_file, iri_file, 0)
 
         flat_n2 = h -> fill(1e18, length(h))
-        model.species[1].density_profile = flat_n2
+        model.species[:N2].density_profile = flat_n2
 
         flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
         sim  = AuroraSimulation(model, flux, savedir; mode=SteadyStateMode())
@@ -215,7 +215,7 @@ end
         run!(sim)
         @test sim.model.initialized
 
-        n2_density = sim.model.species[1].density
+        n2_density = sim.model.species[:N2].density
         @test !isempty(n2_density)
         @test n2_density[1] ≈ 1e18   # bottom of the grid, unaffected by boundary taper
     end

--- a/test/simulation/test_simulation.jl
+++ b/test/simulation/test_simulation.jl
@@ -23,11 +23,11 @@
         initialize!(sim)
 
         @test sim.cache_initialized
-        @test sim.cache.cascading isa AURORA.CascadingCache
         n_species = 3
         @test sim.cache.degradation.secondary_e_flux isa NTuple{n_species, Matrix{Float64}}
         @test sim.cache.degradation.primary_e_spectrum isa NTuple{n_species, Vector{Float64}}
-        @test all(!isempty(species_cache.E_edges) for species_cache in sim.cache.cascading)
+        @test all(sp.cascading_data isa AURORA.SpeciesCascadingCache for sp in sim.model.species)
+        @test all(!isempty(sp.cascading_data.E_edges) for sp in sim.model.species)
         @test size(sim.cache.Ie, 2) == sim.time.n_t_per_loop
         @test size(sim.cache.Ie_top, 2) == length(sim.time.t)
     end

--- a/test/simulation/test_time.jl
+++ b/test/simulation/test_time.jl
@@ -196,20 +196,30 @@ end
     end
 end
 
-@testitem "list_result_files: returns files sorted numerically" setup=[TimeTestModel] begin
+@testitem "list_result_files: returns files sorted numerically" begin
     mktempdir() do savedir
-        flux  = InputFlux(FlatSpectrum(1e-2; E_min=50.0), SmoothOnset(0.0, 0.05); beams=1:2)
-        sim   = AuroraSimulation(TimeTestModel.model, flux, savedir;
-                                 mode=TimeDependentMode(duration=0.11, dt=0.0001,
-                                                        CFL_number=200, n_loop=110))
-        run!(sim)
+        for file in (
+            "IeFlickering-02.mat",
+            "IeFlickering-10.mat",
+            "IeFlickering-01.mat",
+            "IeFlickering-101.mat",
+            "IeFlickering-100.mat",
+            "IeFlickering-110.mat",
+            "IeFlickering-11.mat",
+            "neutral_atm.mat",
+            "Ie_top.mat",
+        )
+            touch(joinpath(savedir, file))
+        end
 
         files = list_result_files(savedir)
-        @test length(files) == 110
+        @test length(files) == 7
         @test endswith(files[1], "IeFlickering-01.mat")
         @test endswith(files[2], "IeFlickering-02.mat")
-        @test endswith(files[100], "IeFlickering-100.mat")
-        @test endswith(files[101], "IeFlickering-101.mat")
+        @test endswith(files[3], "IeFlickering-10.mat")
+        @test endswith(files[4], "IeFlickering-11.mat")
+        @test endswith(files[5], "IeFlickering-100.mat")
+        @test endswith(files[6], "IeFlickering-101.mat")
         @test endswith(files[end], "IeFlickering-110.mat")
     end
 end


### PR DESCRIPTION
Refactors into a modular per-species design, and splits model setup into a constructor plus initialize! step.
Advanced users can now add, remove, or replace neutral species; supply custom density profiles, cross sections, phase functions, and cascading laws; or even change the energy and altitude grids.

Main changes:
- Inside an AuroraModel, a NeutralSpecies now bundles each species' density, cross sections, excitation levels, phase function, and cascading data. All internal functions now iterate on that model.species.
- This introduces the need for a initialize!(model) which does the heavy work (loading/computing matrices for scattering, densities, cross sections, cascading, etc). `run!(sim)`/`initialize!(sim)` call it automatically.


Usage
```julia
model = AuroraModel(alt_lims, θ_lims, E_max, msis_file, iri_file)
model.species[:N2].density_profile = VectorDensity(h, n) # modification of a species
sim = AuroraSimulation(model, flux, savedir; mode)
run!(sim)
```

## TODO
- [x] add an entry in CHANGELOG.md
- [x] update docs
