### PR TITLE
Throw warning only in debug mode

### DIFF
--- a/src/solvers/crank_nicolson.jl
+++ b/src/solvers/crank_nicolson.jl
@@ -127,7 +127,8 @@ function Crank_Nicolson!(Ie, t, model::AuroraModel, v, matrices, iE, Ie_top, I0,
 
     # Check for negative values (if it happens we have a problem) and clamp to zero
     if any(Ie .< 0)
-        @warn "Negative fluxes detected and clamped to zero ($(count(Ie .< 0)) values)"
+        @debug worst = minimum(Ie)
+        @debug "Negative fluxes detected and clamped to zero ($(count(Ie .< 0)) values, worst = $(worst))"
         Ie[Ie .< 0] .= 0
     end
 

--- a/src/solvers/crank_nicolson.jl
+++ b/src/solvers/crank_nicolson.jl
@@ -127,8 +127,17 @@ function Crank_Nicolson!(Ie, t, model::AuroraModel, v, matrices, iE, Ie_top, I0,
 
     # Check for negative values (if it happens we have a problem) and clamp to zero
     if any(Ie .< 0)
-        @debug worst = minimum(Ie)
-        @debug "Negative fluxes detected and clamped to zero ($(count(Ie .< 0)) values, worst = $(worst))"
+        worst = minimum(Ie)
+        worst_index = argmin(Ie)
+        angle_index = (worst_index[1] - 1) ÷ n_z + 1
+        z_index = mod1(worst_index[1], n_z)
+        time_index = worst_index[2]
+        energy = model.energy_grid.E_centers[iE]
+        height = z[z_index]
+        pitch_angle = acosd(μ[angle_index])
+
+        @debug "Negative fluxes detected and clamped to zero ($(count(Ie .< 0)) values, worst = $(worst), " *
+        "at [height = $(height) m, time = $(t[time_index]) s, energy = $(energy) eV, pitch_angle = $(pitch_angle) deg])"
         Ie[Ie .< 0] .= 0
     end
 


### PR DESCRIPTION
And also show what is the worst value.

High CFL values seems to create small instabilities at specific heights, but they are extremely small (e.g. 1e-11 compared to 1e9 fluxes). Put the warning behind a debug statement, and also display the actual "worst" value.
