### PR TITLE
Fix bin-distribution loop in add_inelastic_collisions!

### DIFF
--- a/src/physics/energy_degradation.jl
+++ b/src/physics/energy_degradation.jl
@@ -189,10 +189,12 @@ function add_inelastic_collisions!(Q, Ie, z, n, σ, E_levels, B2B_inelastic, ene
 
                 # Add the degraded electron flux to Q
                 # Q[z,t,E'] += Ie_scatter[z,t] x partition_fraction[E'] x σ x min(1, E_loss/dE)
-                @tturbo for i_u in eachindex(findall(x -> x != 0, partition_fraction))
-                    for j in axes(Q, 2)
+                for i_u in eachindex(partition_fraction)
+                    iE_degrade = i_degrade[i_u]
+                    weight = partition_fraction[i_u] * factor
+                    @tturbo for j in axes(Q, 2)
                         for k in axes(Q, 1)
-                            Q[k, j, i_degrade[i_u]] += Ie_scatter[k, j] * partition_fraction[i_u] * factor
+                            Q[k, j, iE_degrade] += Ie_scatter[k, j] * weight
                         end
                     end
                 end


### PR DESCRIPTION
The loop iterated `eachindex(findall(x -> x != 0, partition_fraction))`, which yields `1:n_nonzero` rather than the nonzero positions, and then indexed `partition_fraction` and `i_degrade` with it. That is only correct when zero fractions are trailing (which is normally the case, where the last bin is zeroed when it coincides with the source bin). For a non-trailing zero it would silently distributes the degraded flux to the wrong energy bins. It also allocated a vector via `findall` on every call inside a hot loop.

Iterate over all partition entries instead — zero fractions contribute nothing — and apply `@tturbo` to the inner `(n_z·n_μ, n_t)` kernel, where it vectorizes a clean affine store rather than a gather/scatter. Verified bit-identical to the intended physics across all zero positions.

The "numerical bug" part was not really a problem because we never encountered the problematic case. But better safe than sorry, and avoiding the allocation of `findall` should yield a small performance improvement.

Written by Claude, reviewed by me.