### PR TITLE
docs: PR doc previews + gh-pages cleanup

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -1,0 +1,33 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# Ensure that only one "Doc Preview Cleanup" workflow force-pushes at a time
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+      - name: Delete preview and history + push changes
+        run: |
+          if [ -d "${preview_dir}" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "${preview_dir}"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+          fi
+        env:
+          preview_dir: previews/PR${{ github.event.number }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -106,4 +106,7 @@ for d in data_dirs
     rm(d; recursive=true)
 end
 
-deploydocs(; repo = "github.com/egavazzi/AURORA.jl")
+deploydocs(;
+    repo = "github.com/egavazzi/AURORA.jl",
+    push_preview = true, # deploy PR builds to previews/PR##/ for review on the branch
+)


### PR DESCRIPTION
Deploy the docs on pull requests at `https://egavazzi.github.io/AURORA.jl/previews/PR<number>/` which allows to preview them.

Also implement the official Documenter cleanup workflow in a new `.github/workflows/DocCleanup.yml` (new). On PR close it:
  - removes PR's `previews/PR##/` folder when a PR closes
  - and squashes the entire `gh-pages` commit history into a single commit (force-push), to prevent long-term `gh-pages` growth.
