### PR TITLE
fix: repair check_n_loop memory check (undefined `warn`, swapped branches)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Switch from IRI2016 to IRI2020 model, solving the issue with recent dates that could not be computed [#117](https://github.com/egavazzi/AURORA.jl/pull/117)
 - Handle invalid iri values at top and bottom ends [#118](https://github.com/egavazzi/AURORA.jl/pull/118)
 - Cached cascading and scattering matrices created with different versions of AURORA are now automatically skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
+- Fix `check_n_loop` memory check: it called the undefined `warn` (now `@warn`) and had its warning/error thresholds swapped so the out-of-RAM `error` branch was unreachable
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - Switch from IRI2016 to IRI2020 model, solving the issue with recent dates that could not be computed [#117](https://github.com/egavazzi/AURORA.jl/pull/117)
 - Handle invalid iri values at top and bottom ends [#118](https://github.com/egavazzi/AURORA.jl/pull/118)
 - Cached cascading and scattering matrices created with different versions of AURORA are now automatically skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
-- Fix `check_n_loop` memory check: it called the undefined `warn` (now `@warn`) and had its warning/error thresholds swapped so the out-of-RAM `error` branch was unreachable
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -418,17 +418,17 @@ function check_n_loop(n_loop, n_z, n_μ, n_t, n_E)
     total_ram_gb = Sys.total_memory() / 1024^3
     estimated_memory_gb = estimate_simulation_memory(n_z, n_μ, n_t, n_E)
     memory_per_loop_gb = estimated_memory_gb / n_loop
-    if memory_per_loop_gb > total_ram_gb * 0.5
-        warn("The n_loop = $n_loop may lead to high memory usage.\n" *
-             "Estimated memory per loop: $(round(memory_per_loop_gb, digits=2)) GB\n" *
-             "Maximum RAM available (detected): $(round(total_ram_gb, digits=2)) GB\n" *
-             "Consider increasing `n_loop` or or decreasing `max_memory_gb` to avoid issues.")
-    elseif memory_per_loop_gb > total_ram_gb
+    if memory_per_loop_gb > total_ram_gb
         error("The n_loop = $n_loop is too small for simulations to fit in available RAM.\n" *
               "Estimated memory per loop: $(round(memory_per_loop_gb, digits=2)) GB\n" *
               "Maximum RAM available (detected): $(round(total_ram_gb, digits=2)) GB\n" *
               "Please increase `n_loop` to at least $(ceil(Int, estimated_memory_gb / total_ram_gb)) " *
               "or decrease `max_memory_gb`.")
+    elseif memory_per_loop_gb > total_ram_gb * 0.5
+        @warn("The n_loop = $n_loop may lead to high memory usage.\n" *
+              "Estimated memory per loop: $(round(memory_per_loop_gb, digits=2)) GB\n" *
+              "Maximum RAM available (detected): $(round(total_ram_gb, digits=2)) GB\n" *
+              "Consider increasing `n_loop` or decreasing `max_memory_gb` to avoid issues.")
     end
 end
 


### PR DESCRIPTION
### Summary
`check_n_loop` (`src/utilities.jl`) crashed whenever the estimated per-loop memory exceeded half the detected RAM — which happens for large grids or a small `CFL_number`. Instead of warning, it threw:

```
UndefVarError: `warn` not defined
```

### Cause
Two bugs in the memory check:
1. It called `warn(...)`, which is not a function in modern Julia (it should be the `@warn` macro).
2. The branches were in the wrong order: the `> total_ram_gb * 0.5` **warning** was checked first, so the fatal `> total_ram_gb` **error** branch was unreachable.

(There was also an "or or" typo in the message.)

### Fix
- `warn(...)` → `@warn(...)`.
- Check the fatal `> total_ram_gb` case first, then the `> 0.5 × total_ram_gb` warning.
- Fix the typo.

---
_Generated by [Claude Code](https://claude.ai/code/session_013P8AAbdTSeDVhvLyzCuoWH)_