### PR TITLE
perf: fuse the energy-degradation accumulation in update_Q!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Handle invalid iri values at top and bottom ends [#118](https://github.com/egavazzi/AURORA.jl/pull/118)
 - Cached cascading and scattering matrices created with different versions of AURORA are now automatically skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
 - Performance: remove per-energy-step allocations in the transport solver hot path (`update_A!`/`update_B!`, the Crank-Nicolson and steady-state schemes, and the ionization branch of `update_Q!`), reducing allocations in the energy loop by ~25% with identical results. The energy loop is `@tturbo`-threaded, so running Julia with multiple threads (`julia -t auto`) gives a large additional speedup (e.g. ~1.8× on 4 threads).
+- Performance: fuse the energy-degradation accumulation in `update_Q!`. The inelastic (non-ionizing) losses, ionization secondaries and degraded primaries of all neutral species are now collapsed into per-target-bin weight vectors and written into `Q` in a single pass (`add_degradation_collisions!`), instead of one pass per species/excitation-level/target-bin. This cuts the `update_Q!` time by ~11% at `E_max = 500 eV` and ~15% at `E_max = 3000 eV` (the gain grows with `E_max`, where the O(n_E²) degradation dominates). Results are numerically identical (max relative difference ~1e-14).
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/scripts/bench_degradation.jl
+++ b/scripts/bench_degradation.jl
@@ -1,0 +1,91 @@
+# Benchmark + numerical-identity harness for the update_Q! energy-degradation kernel.
+#
+# Usage:
+#   julia --project=. -t 4 scripts/bench_degradation.jl baseline <E_max>
+#   julia --project=. -t 4 scripts/bench_degradation.jl compare  <E_max>
+#
+# "baseline" : runs a full solve, serializes the realistic input flux Ie and the
+#              Q array produced by a controlled update_Q! re-sweep (the reference).
+# "compare"  : reloads the SAME Ie, re-sweeps update_Q!, and compares Q against the
+#              reference -> isolates the kernel change (identical input).
+#
+# Both modes print the summed wall-clock time of update_Q! over the full energy loop.
+
+using AURORA
+using Serialization: serialize, deserialize
+
+const MODE  = length(ARGS) >= 1 ? ARGS[1] : "baseline"
+const E_MAX = length(ARGS) >= 2 ? parse(Float64, ARGS[2]) : 500.0
+const TAG   = "emax$(Int(E_MAX))"
+const IE_FILE = "/tmp/degr_Ie_$(TAG).bin"
+const Q_FILE  = "/tmp/degr_Qref_$(TAG).bin"
+
+const REFROOT = joinpath(@__DIR__, "..", "test", "regression", "reference_results")
+const MSIS = joinpath(REFROOT, "msis_20051008-2200_70N-19E.txt")
+const IRI  = joinpath(REFROOT, "iri_20051008-2200_70N-19E.txt")
+
+function build_sim()
+    altitude_lims = [100, 400]
+    θ_lims = 180:-30:0
+    B_angle_to_zenith = 13
+    model = AuroraModel(altitude_lims, θ_lims, E_MAX, MSIS, IRI, B_angle_to_zenith)
+    savedir = mktempdir()
+    flux = InputFlux(FlatSpectrum(1e-2; E_min=100.0), SinusoidalFlickering(5.0);
+                     beams=1, z_source=1000.0)
+    sim = AuroraSimulation(model, flux, savedir;
+                           mode=TimeDependentMode(duration=0.05, dt=0.01,
+                                                  CFL_number=128, n_loop=1))
+    AURORA.initialize!(sim; force_recompute=true, verbose=false)
+    return sim
+end
+
+# Controlled re-sweep: rebuild Q from a fixed Ie, timing only update_Q!.
+function sweep_updateQ!(sim, Ie; nrep=3)
+    cache = AURORA.get_cache(sim)
+    model = sim.model
+    matrices = cache.matrices
+    n_E = model.energy_grid.n
+    best = Inf
+    for _ in 1:nrep
+        fill!(matrices.Q, 0.0)
+        t = 0.0
+        for iE in n_E:-1:1
+            B2B = AURORA.update_matrices!(matrices, model, iE, cache.B2B_fragment)
+            t += @elapsed AURORA.update_Q!(matrices, Ie, model, cache.t_loop,
+                                           B2B, iE, cache.degradation)
+        end
+        best = min(best, t)
+    end
+    return best, matrices.Q
+end
+
+sim = build_sim()
+cache = AURORA.get_cache(sim)
+model = sim.model
+n_E = model.energy_grid.n
+sz = size(cache.Ie)
+println("E_max=$(E_MAX)  n_E=$(n_E)  Ie size=$(sz)  n_species=$(length(model.species))  threads=$(Threads.nthreads())")
+
+if MODE == "baseline"
+    run!(sim)                                # realistic Ie at every energy
+    Ie = copy(cache.Ie)
+    serialize(IE_FILE, Ie)
+    t, Q = sweep_updateQ!(sim, Ie)
+    serialize(Q_FILE, copy(Q))
+    println("BASELINE update_Q! total = $(round(t*1e3, digits=2)) ms")
+    println("  sum(Q)=$(sum(Q))  sum(abs Q)=$(sum(abs, Q))")
+elseif MODE == "compare"
+    Ie = deserialize(IE_FILE)::Array{Float64,3}
+    @assert size(Ie) == sz "Ie size mismatch; regenerate baseline for this E_max"
+    Qref = deserialize(Q_FILE)::Array{Float64,3}
+    t, Q = sweep_updateQ!(sim, Ie)
+    println("COMPARE  update_Q! total = $(round(t*1e3, digits=2)) ms")
+    absdiff = maximum(abs.(Q .- Qref))
+    denom = max.(abs.(Q), abs.(Qref), eps())
+    reldiff = maximum(abs.(Q .- Qref) ./ denom)
+    println("  max |ΔQ|       = $(absdiff)")
+    println("  max rel ΔQ     = $(reldiff)")
+    println("  sum(Q)=$(sum(Q))  sum(Qref)=$(sum(Qref))")
+else
+    error("unknown mode $MODE")
+end

--- a/src/physics/energy_degradation.jl
+++ b/src/physics/energy_degradation.jl
@@ -1,9 +1,5 @@
 using LoopVectorization: @tturbo
 
-#################################################################################
-#                                   Update Q                                    #
-#################################################################################
-
 function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
                    B2B_inelastic_neutrals, iE, cache)
 
@@ -45,10 +41,8 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
         B2B_inelastic = B2B_inelastic_neutrals[i]
         species_cascading = sp.cascading_data
 
-        # ── Inelastic (non-ionizing) collisions ──
-        # Compute the scattered flux and the per-target-bin degradation weights, but
-        # do NOT accumulate into Q here. The accumulation is fused below across all
-        # species and channels so that Q is swept only once.
+        # Inelastic (non-ionizing) collisions
+        # Compute the scattered flux and the per-target-bin degradation weights
         calculate_scattered_flux!(Ie_scatter[i], B2B_inelastic, n, @view(Ie[:, :, iE]))
         compute_inelastic_weights!(inelastic_weight[i], σ, E_levels, energy_grid, iE)
 
@@ -73,11 +67,9 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
                                         σ, E_levels, species_cascading, iE)
         end
     end
+
     # Fused accumulation into Q for ALL degradation channels (inelastic losses +
-    # ionization secondaries + degraded primaries) of ALL species. This touches the
-    # lower-energy block of Q exactly once per energy step instead of once per
-    # species/excitation-level/target-bin. Skipped entirely when there is nothing to
-    # degrade (lowest energy bin, or all contributions zero).
+    # ionization secondaries + degraded primaries) of ALL species.
     has_degradation = any(!iszero, inelastic_weight) ||
                       any(!iszero, secondary_e_spectrum) ||
                       any(!iszero, primary_e_spectrum)
@@ -103,12 +95,6 @@ function add_thermal_electron_collisions!(Q_slice, Ie_slice, thermal_e_loss, ΔE
     return nothing
 end
 
-
-
-
-#################################################################################
-#                               Inelastic collisions                            #
-#################################################################################
 
 """
     calculate_scattered_flux!(result, B2B_inelastic, n, Ie_slice)
@@ -160,11 +146,22 @@ function calculate_scattered_flux!(result, B2B_inelastic, n, Ie_slice)
     return nothing
 end
 
-# Partition fraction for position `u` (1-based) within the target bin range `i_degrade`,
-# replicating the original first/middle/last bin handling exactly. The last position is
-# evaluated first so that a single-bin range (u == 1 == n_deg) uses the "last" formula,
-# matching the original code where partition_fraction[end] overwrote partition_fraction[1].
-@inline function inelastic_partition_fraction(u, n_deg, i_degrade, iE, E_loss, E_edges, ΔE)
+# After losing `E_loss` eV, an electron starting anywhere in source bin `iE` lands somewhere
+# in the energy interval [E_edges[iE] - E_loss, E_edges[iE+1] - E_loss]. That interval spans
+# the consecutive target bins `i_degrade = i_min:i_max`. This returns how much of the interval
+# falls into the target bin at position `u` (within `i_degrade`), expressed as a
+# fraction of the source bin width ΔE[iE]:
+#   - interior bins that are fully covered                 → ΔE[target] / ΔE[iE]
+#   - the first/last bins that are only partially covered  → use the actual overlap width
+# The returned values are unnormalized; the caller divides by their sum so they partition the
+# degraded flux. Each result is also capped at 1 so a single target bin can never receive more
+# than the whole source bin.
+#
+# The `u == n_deg` branch is tested before `u == 1` so that a single-bin range (n_deg == 1, so
+# u == 1 == n_deg) uses the last-bin overlap formula. That branch also returns 0 when the only
+# target bin is `iE` itself, i.e. the electron stays in its source bin and there is no
+# degradation.
+function inelastic_partition_fraction(u, n_deg, i_degrade, iE, E_loss, E_edges, ΔE)
     if u == n_deg
         idx_end = i_degrade[n_deg]
         idx_end == iE && return 0.0
@@ -192,7 +189,6 @@ together with the species' scattered flux `Ie_scatter`, so that
 ```
     Q[:, :, iE_degrade] += Ie_scatter[:, :] × weight[iE_degrade]
 ```
-This replaces the original per-channel accumulation directly into Q.
 
 # Arguments
 - `weight`: output vector (n_E,), overwritten with the degradation weights
@@ -246,10 +242,6 @@ end
 
 
 
-
-#################################################################################
-#                               Ionization collisions                           #
-#################################################################################
 
 #=
 The three functions below compute the ionization contribution to Q more efficiently

--- a/src/physics/energy_degradation.jl
+++ b/src/physics/energy_degradation.jl
@@ -29,7 +29,9 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
                                          cache.thermal_e_loss, ΔE[iE], n_z, n_μ)
     end
 
-    # Get the pre-allocated ionization arrays from cache
+    # Get the pre-allocated degradation arrays from cache
+    Ie_scatter           = cache.Ie_scatter
+    inelastic_weight     = cache.inelastic_weight
     secondary_e_flux     = cache.secondary_e_flux
     primary_e_flux       = cache.primary_e_flux
     secondary_e_spectrum = cache.secondary_e_spectrum
@@ -43,7 +45,12 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
         B2B_inelastic = B2B_inelastic_neutrals[i]
         species_cascading = sp.cascading_data
 
-        add_inelastic_collisions!(Q, Ie, z, n, σ, E_levels, B2B_inelastic, energy_grid, iE, cache)
+        # ── Inelastic (non-ionizing) collisions ──
+        # Compute the scattered flux and the per-target-bin degradation weights, but
+        # do NOT accumulate into Q here. The accumulation is fused below across all
+        # species and channels so that Q is swept only once.
+        calculate_scattered_flux!(Ie_scatter[i], B2B_inelastic, n, @view(Ie[:, :, iE]))
+        compute_inelastic_weights!(inelastic_weight[i], σ, E_levels, energy_grid, iE)
 
         # Zero out the ionization arrays for this species
         fill!(secondary_e_flux[i], 0)
@@ -66,14 +73,19 @@ function update_Q!(matrices::TransportMatrices, Ie, model::AuroraModel, t,
                                         σ, E_levels, species_cascading, iE)
         end
     end
-    # If there is no ionization to add (everything is zero), skip the update of Q
-    # Mmh the compiler seems to be smart enough to skip the update of Q anyway when
-    # everything is zero. But let's keep this if statement just in case.
-    has_ionization = any(!iszero, secondary_e_spectrum) || any(!iszero, primary_e_spectrum)
-    if has_ionization
-        add_ionization_collisions!(Q, iE,
-                                   secondary_e_flux, primary_e_flux,
-                                   secondary_e_spectrum, primary_e_spectrum)
+    # Fused accumulation into Q for ALL degradation channels (inelastic losses +
+    # ionization secondaries + degraded primaries) of ALL species. This touches the
+    # lower-energy block of Q exactly once per energy step instead of once per
+    # species/excitation-level/target-bin. Skipped entirely when there is nothing to
+    # degrade (lowest energy bin, or all contributions zero).
+    has_degradation = any(!iszero, inelastic_weight) ||
+                      any(!iszero, secondary_e_spectrum) ||
+                      any(!iszero, primary_e_spectrum)
+    if iE > 1 && has_degradation
+        add_degradation_collisions!(Q, iE,
+                                    Ie_scatter, inelastic_weight,
+                                    secondary_e_flux, primary_e_flux,
+                                    secondary_e_spectrum, primary_e_spectrum)
     end
 end
 
@@ -148,65 +160,88 @@ function calculate_scattered_flux!(result, B2B_inelastic, n, Ie_slice)
     return nothing
 end
 
-function add_inelastic_collisions!(Q, Ie, z, n, σ, E_levels, B2B_inelastic, energy_grid::EnergyGrid, iE, cache)
+# Partition fraction for position `u` (1-based) within the target bin range `i_degrade`,
+# replicating the original first/middle/last bin handling exactly. The last position is
+# evaluated first so that a single-bin range (u == 1 == n_deg) uses the "last" formula,
+# matching the original code where partition_fraction[end] overwrote partition_fraction[1].
+@inline function inelastic_partition_fraction(u, n_deg, i_degrade, iE, E_loss, E_edges, ΔE)
+    if u == n_deg
+        idx_end = i_degrade[n_deg]
+        idx_end == iE && return 0.0
+        return min(1.0, (E_edges[iE + 1] - E_edges[idx_end] - E_loss) / ΔE[iE])
+    elseif u == 1
+        return min(1.0, (E_edges[i_degrade[1] + 1] - E_edges[iE] + E_loss) / ΔE[iE])
+    else
+        return min(1.0, ΔE[i_degrade[u]] / ΔE[iE])
+    end
+end
+
+"""
+    compute_inelastic_weights!(weight, σ, E_levels, energy_grid, iE)
+
+Compute, for one neutral species, the per-target-bin energy-degradation weights from
+non-ionizing inelastic collisions of an electron at energy index `iE`.
+
+`weight[iE_degrade]` accumulates, over every non-ionizing excitation channel,
+```
+    partition_fraction × σ[level, iE] × min(1, E_loss / ΔE[iE])
+```
+where `partition_fraction` distributes the degraded electrons over the lower-energy bins
+they fall into. The weights are consumed once by the fused `add_degradation_collisions!`
+together with the species' scattered flux `Ie_scatter`, so that
+```
+    Q[:, :, iE_degrade] += Ie_scatter[:, :] × weight[iE_degrade]
+```
+This replaces the original per-channel accumulation directly into Q.
+
+# Arguments
+- `weight`: output vector (n_E,), overwritten with the degradation weights
+- `σ`: cross-sections for this species (n_levels × n_E)
+- `E_levels`: excitation-level table (column 1 = energy loss, column 2 = #secondaries)
+- `energy_grid::EnergyGrid`
+- `iE`: current energy index
+"""
+function compute_inelastic_weights!(weight, σ, E_levels, energy_grid::EnergyGrid, iE)
     E_edges = energy_grid.E_edges
     ΔE = energy_grid.ΔE
-    # Use cached matrices to avoid allocations
-    Ie_scatter = cache.Ie_scatter
 
-    # Calculate the flux of electrons after pitch-angle scattering by inelastic collisions
-    # This is computed ONCE for all energy levels of this species at this energy
-    calculate_scattered_flux!(Ie_scatter, B2B_inelastic, n, @view(Ie[:, :, iE]))
+    fill!(weight, 0.0)
 
-    # Loop over the energy levels of the collisions with the i-th neutral species
+    # Loop over the energy levels of the collisions with this neutral species
     for i_level in axes(E_levels, 1)[2:end]
-        if E_levels[i_level, 2] <= 0  # these collisions should not produce secondary e-
-            # Calculate the degradation factor combining:
-            # 1) Cross-section σ[i_level, iE] - collision probability
-            # 2) Energy loss correction min(1, E_loss/ΔE[iE]) - accounts for when the energy
-            #    loss is smaller than the bin width (prevents over-depleting the current bin)
-            factor = σ[i_level, iE] * min(1, E_levels[i_level, 1] / ΔE[iE])
+        E_levels[i_level, 2] <= 0 || continue  # only collisions that do not produce secondary e-
 
-            # Find the energy bins where electrons will end up after losing E_levels[i_level, 1] eV
-            E_loss = E_levels[i_level, 1]
-            E_min = E_edges[iE] - E_loss           # Minimum energy after collision
-            E_max = E_edges[iE+1] - E_loss         # Maximum energy after collision
-            # Find indices where degraded electrons end up
-            i_min = searchsortedfirst(@view(E_edges[2:end]), E_min)  # First bin with upper edge > E_min
-            i_max = searchsortedlast(@view(E_edges[1:end-1]), E_max) # Last bin with lower edge < E_max
-            i_degrade = i_min:i_max
-            partition_fraction = zeros(length(i_degrade)) # initialise
+        # Degradation factor combining:
+        # 1) Cross-section σ[i_level, iE] - collision probability
+        # 2) Energy loss correction min(1, E_loss/ΔE[iE]) - accounts for when the energy
+        #    loss is smaller than the bin width (prevents over-depleting the current bin)
+        E_loss = E_levels[i_level, 1]
+        factor = σ[i_level, iE] * min(1.0, E_loss / ΔE[iE])
 
-            if !isempty(i_degrade) && i_degrade[1] < iE
-                # Distribute the degrading e- between those bins
-                partition_fraction[1] = min(1, (E_edges[i_degrade[1]+1] -
-                                                E_edges[iE] + E_levels[i_level, 1]) / ΔE[iE])
-                if length(i_degrade) > 2
-                    partition_fraction[2:end-1] = min.(1, ΔE[i_degrade[2:end-1]] / ΔE[iE])
-                end
-                partition_fraction[end] = min(1, (E_edges[iE+1] - E_edges[i_degrade[end]] -
-                                                    E_levels[i_level, 1]) / ΔE[iE])
-                if i_degrade[end] == iE
-                    partition_fraction[end] = 0
-                end
+        # Find the energy bins where electrons will end up after losing E_loss eV
+        E_min = E_edges[iE] - E_loss           # Minimum energy after collision
+        E_max = E_edges[iE + 1] - E_loss       # Maximum energy after collision
+        i_min = searchsortedfirst(@view(E_edges[2:end]), E_min)   # First bin with upper edge > E_min
+        i_max = searchsortedlast(@view(E_edges[1:end - 1]), E_max) # Last bin with lower edge < E_max
+        i_degrade = i_min:i_max
+        (isempty(i_degrade) || i_degrade[1] >= iE) && continue
 
-                # Normalize partition fractions to sum to 1
-                partition_fraction = partition_fraction / sum(partition_fraction)
+        n_deg = length(i_degrade)
 
-                # Add the degraded electron flux to Q
-                # Q[z,t,E'] += Ie_scatter[z,t] x partition_fraction[E'] x σ x min(1, E_loss/dE)
-                for i_u in eachindex(partition_fraction)
-                    iE_degrade = i_degrade[i_u]
-                    weight = partition_fraction[i_u] * factor
-                    @tturbo for j in axes(Q, 2)
-                        for k in axes(Q, 1)
-                            Q[k, j, iE_degrade] += Ie_scatter[k, j] * weight
-                        end
-                    end
-                end
-            end
+        # Normalize the partition fractions to sum to 1, then accumulate into `weight`.
+        sum_pf = 0.0
+        for u in 1:n_deg
+            sum_pf += inelastic_partition_fraction(u, n_deg, i_degrade, iE, E_loss, E_edges, ΔE)
+        end
+        sum_pf > 0 || continue
+        norm_factor = factor / sum_pf
+        for u in 1:n_deg
+            pf = inelastic_partition_fraction(u, n_deg, i_degrade, iE, E_loss, E_edges, ΔE)
+            weight[i_degrade[u]] += pf * norm_factor
         end
     end
+
+    return nothing
 end
 
 
@@ -245,13 +280,16 @@ The factorization in Part 2 is the key optimization: all ionization channels of 
 are collapsed into a single spectrum vector, so the expensive (n_E × n_z × n_μ × n_t)
 accumulation into Q only needs to run once per species instead of once per channel.
 
-The final accumulation into Q is done in `add_ionization_collisions!`:
+The final accumulation into Q is done in `add_degradation_collisions!`, which fuses these
+ionization terms together with the inelastic degradation term (`Ie_scatter × inelastic_weight`,
+see `compute_inelastic_weights!`) into a single pass over Q:
 ```julia
 for i_s in eachindex(secondary_e_flux)
     for iI in 1:(iE - 1)
         for j in axes(Q, 2)
             for k in axes(Q, 1)
-                Q[k, j, iI] += secondary_e_flux[i_s][k, j] * secondary_e_spectrum[i_s][iI] +  # secondaries of species i_s
+                Q[k, j, iI] += Ie_scatter[i_s][k, j]     * inelastic_weight[i_s][iI] +     # inelastic degradation of species i_s
+                               secondary_e_flux[i_s][k, j] * secondary_e_spectrum[i_s][iI] + # secondaries of species i_s
                                primary_e_flux[i_s][k, j]   * primary_e_spectrum[i_s][iI]      # degraded primaries of species i_s
             end
         end
@@ -340,14 +378,19 @@ function compute_ionization_spectra!(secondary_e_spectrum, primary_e_spectrum,
     end
 end
 
-@generated function add_ionization_collisions!(Q, iE,
-                                               secondary_e_flux::NTuple{N, <:AbstractMatrix},
-                                               primary_e_flux::NTuple{N, <:AbstractMatrix},
-                                               secondary_e_spectrum::NTuple{N, <:AbstractVector},
-                                               primary_e_spectrum::NTuple{N, <:AbstractVector}) where {N}
+@generated function add_degradation_collisions!(Q, iE,
+                                                Ie_scatter::NTuple{N, <:AbstractMatrix},
+                                                inelastic_weight::NTuple{N, <:AbstractVector},
+                                                secondary_e_flux::NTuple{N, <:AbstractMatrix},
+                                                primary_e_flux::NTuple{N, <:AbstractMatrix},
+                                                secondary_e_spectrum::NTuple{N, <:AbstractVector},
+                                                primary_e_spectrum::NTuple{N, <:AbstractVector}) where {N}
 
-    # Unroll the loop over species to accumulate in Q only once and reduce memory access.
-    terms = [:(secondary_e_flux[$i_s][k, j] * secondary_e_spectrum[$i_s][iI] +
+    # Unroll the loop over species so that Q is accumulated in a single pass, fusing all
+    # three degradation channels (inelastic losses + ionization secondaries + degraded
+    # primaries) and reducing memory traffic on the large Q array.
+    terms = [:(Ie_scatter[$i_s][k, j] * inelastic_weight[$i_s][iI] +
+               secondary_e_flux[$i_s][k, j] * secondary_e_spectrum[$i_s][iI] +
                primary_e_flux[$i_s][k, j] * primary_e_spectrum[$i_s][iI])
              for i_s in 1:N]
     rhs = reduce((a, b) -> :($a + $b), terms)

--- a/src/simulation/cache.jl
+++ b/src/simulation/cache.jl
@@ -30,7 +30,8 @@ end
 mutable struct DegradationCache{N}
     ionization_source_sum::Matrix{Float64}           # total incident flux summed over beams (shape: n_z x n_t)
     thermal_e_loss::Vector{Float64}
-    Ie_scatter::Matrix{Float64}
+    Ie_scatter::NTuple{N, Matrix{Float64}}           # inelastically-scattered flux per species (shape: n_z·n_μ x n_t)
+    inelastic_weight::NTuple{N, Vector{Float64}}     # energy degradation weighting for inelastic losses per species (shape: n_E)
     secondary_e_flux::NTuple{N, Matrix{Float64}}     # isotropic secondary e- flux per species (shape: n_z·n_μ x n_t)
     primary_e_flux::NTuple{N, Matrix{Float64}}       # forward primary e- flux per species    (shape: n_z·n_μ x n_t)
     secondary_e_spectrum::NTuple{N, Vector{Float64}} # energy spectrum weighting for secondaries per species (shape: n_E)
@@ -41,14 +42,16 @@ end
 function DegradationCache{N}(n_μ::Int, n_t::Int, n_z::Int, n_E::Int) where {N}
     ionization_source_sum = Matrix{Float64}(undef, n_z, n_t)
     thermal_e_loss = Vector{Float64}(undef, n_z)
-    Ie_scatter = Matrix{Float64}(undef, n_z * n_μ, n_t)
+    Ie_scatter = ntuple(_ -> Matrix{Float64}(undef, n_z * n_μ, n_t), Val(N))
+    inelastic_weight = ntuple(_ -> zeros(n_E), Val(N))
 
     secondary_e_flux = ntuple(_ -> zeros(n_z * n_μ, n_t), Val(N))
     primary_e_flux = ntuple(_ -> zeros(n_z * n_μ, n_t), Val(N))
     secondary_e_spectrum = ntuple(_ -> zeros(n_E), Val(N))
     primary_e_spectrum = ntuple(_ -> zeros(n_E), Val(N))
 
-    return DegradationCache(ionization_source_sum, thermal_e_loss, Ie_scatter,
+    return DegradationCache(ionization_source_sum, thermal_e_loss,
+                            Ie_scatter, inelastic_weight,
                             secondary_e_flux, primary_e_flux,
                             secondary_e_spectrum, primary_e_spectrum)
 end


### PR DESCRIPTION
### Summary
Fuses the energy-degradation accumulation in `update_Q!` into a single pass over `Q`.

### Motivation
The inelastic (non-ionizing) degradation previously swept the large `Q` array once per **species × excitation-level × target-bin**, while the ionization channels already used a single fused pass.

### Change
- `compute_inelastic_weights!`: collapse all non-ionizing excitation channels of a species into a per-target-bin weight vector (the spatial/angular flux factors out, exactly as already done for ionization).
- `add_degradation_collisions!`: a single `@generated`, species-unrolled `@tturbo` pass writes the inelastic losses **and** ionization secondaries **and** degraded primaries into `Q`'s lower-energy block in one sweep, instead of many.

### Benchmarks (isolated `update_Q!`, identical input `Ie`, 4 threads)
| E_max | n_E | before | after | speedup |
|------:|----:|-------:|------:|--------:|
| 500 eV | 121 | 313 ms | 279 ms | ~11% |
| 3000 eV | 336 | 5201 ms | 4434 ms | ~15% |

### Correctness
- Fused kernel vs. original on identical `Ie`: max relative ΔQ ≈ 2e-15 (roundoff).
- Full steady-state and time-dependent regression references match to ≈ 2.5e-14 (tolerance 1e-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)