### PR TITLE
Fix fragile loop partitioning and rework memory estimation

### DIFF
--- a/src/simulation/initialize.jl
+++ b/src/simulation/initialize.jl
@@ -23,7 +23,7 @@ function initialize!(sim::AuroraSimulation;
         initialize!(sim.model; policy=cache_policy, verbose)
     end
     # Rebuild the time configuration from the (possibly changed) model grids.
-    sim.time = build_time_config(sim.model, sim.mode)
+    sim.time = build_time_config(sim.model, sim.mode; verbose)
     sim.cache = build_simulation_cache(sim; cache_policy)
     sim.cache_initialized = true
     return nothing

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -267,7 +267,7 @@ struct RefinedTimeGrid{TI<:AbstractRange{Float64}, TS<:AbstractRange{Float64}} <
     n_t_per_loop::Int    # = n_save_per_loop * CFL_factor + 1  (max internal steps per loop)
 end
 
-function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode)
+function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode; verbose::Bool=false)
     duration = mode.duration
     dt = mode.dt
     CFL_number = mode.CFL_number
@@ -293,7 +293,7 @@ function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode)
     # The automatic path is already capped at n_save inside calculate_n_loop.
     n_loop_resolved = isnothing(n_loop) ?
         calculate_n_loop(length(z), n_μ, n_E, length(t_internal), N_neutrals, CFL_factor,
-                         n_save; max_memory_gb) :
+                         n_save; max_memory_gb, verbose) :
         Int(n_loop)
 
     # A loop holds at least one save interval, so there cannot be more loops than save
@@ -307,7 +307,7 @@ function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode)
 
     # Check that the chosen split actually fits in RAM
     check_n_loop(n_loop_resolved, length(z), n_μ, n_E, length(t_internal), N_neutrals,
-                 CFL_factor)
+                 CFL_factor; verbose)
 
     # Save intervals are partitioned across loops as evenly as possible (balanced
     # partition, see `loop_save_count`): the first `rem(n_save, n_loop)` loops get
@@ -449,11 +449,14 @@ function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir::Abstract
     return AuroraSimulation(model, flux, output; mode)
 end
 
-# Build the appropriate time configuration based on the mode
-build_time_config(model::AuroraModel, mode::SteadyStateMode) =
+# Build the appropriate time configuration based on the mode.
+# `verbose` is forwarded to the (potentially noisy) automatic n_loop calculation; it
+# defaults to `false` so that constructing an `AuroraSimulation` stays quiet, while
+# `initialize!`/`run!` can opt in to the printout.
+build_time_config(model::AuroraModel, mode::SteadyStateMode; verbose::Bool=false) =
     is_multi_step(mode) ? UniformTimeGrid(mode.duration, mode.dt) : SingleStepConfig()
-build_time_config(model::AuroraModel, mode::TimeDependentMode) =
-    RefinedTimeGrid(model, mode)
+build_time_config(model::AuroraModel, mode::TimeDependentMode; verbose::Bool=false) =
+    RefinedTimeGrid(model, mode; verbose)
 
 function Base.show(io::IO, sim::AuroraSimulation)
     mode_name = sim.mode isa SteadyStateMode ? "steady-state" : "time-dependent"

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -263,7 +263,7 @@ struct RefinedTimeGrid{TI<:AbstractRange{Float64}, TS<:AbstractRange{Float64}} <
     t_save::TS           # coarse save grid          (length = n_save + 1)
     n_save::Int          # total number of save intervals = round(Int, duration / dt)
     n_loop::Int
-    n_save_per_loop::Int # = cld(n_save, n_loop). Max save intervals per loop (for allocation)
+    n_save_per_loop::Int # = cld(n_save, n_loop) (max save intervals per loop)
     n_t_per_loop::Int    # = n_save_per_loop * CFL_factor + 1  (max internal steps per loop)
 end
 
@@ -450,9 +450,6 @@ function AuroraSimulation(model::AuroraModel, flux::InputFlux, savedir::Abstract
 end
 
 # Build the appropriate time configuration based on the mode.
-# `verbose` is forwarded to the (potentially noisy) automatic n_loop calculation; it
-# defaults to `false` so that constructing an `AuroraSimulation` stays quiet, while
-# `initialize!`/`run!` can opt in to the printout.
 build_time_config(model::AuroraModel, mode::SteadyStateMode; verbose::Bool=false) =
     is_multi_step(mode) ? UniformTimeGrid(mode.duration, mode.dt) : SingleStepConfig()
 build_time_config(model::AuroraModel, mode::TimeDependentMode; verbose::Bool=false) =

--- a/src/simulation/types.jl
+++ b/src/simulation/types.jl
@@ -247,8 +247,9 @@ then the fine internal grid (`t`) is obtained by subdividing each save interval 
 CFL condition is satisfied. The end result is a grid with `CFL_factor` sub-steps per save
 interval.
 
-Loops are partitioned by save intervals using ceiling division, so all loops have exactly
-`n_save_per_loop` save intervals, except the last one which gets the remainder (if any).
+Loops are partitioned by save intervals using a balanced partition (loop sizes differ by at
+most one), so every loop holds between `fld(n_save, n_loop)` and `cld(n_save, n_loop)` save
+intervals and none is ever empty (for `n_loop ≤ n_save`).
 
 See [`loop_save_count`](@ref), [`loop_save_start`](@ref), [`loop_internal_count`](@ref),
 [`loop_internal_start`](@ref) for helpers to index into these grids per loop.
@@ -262,7 +263,7 @@ struct RefinedTimeGrid{TI<:AbstractRange{Float64}, TS<:AbstractRange{Float64}} <
     t_save::TS           # coarse save grid          (length = n_save + 1)
     n_save::Int          # total number of save intervals = round(Int, duration / dt)
     n_loop::Int
-    n_save_per_loop::Int # = cld(n_save, n_loop). Last loop gets the remainder (≤ than this)
+    n_save_per_loop::Int # = cld(n_save, n_loop). Max save intervals per loop (for allocation)
     n_t_per_loop::Int    # = n_save_per_loop * CFL_factor + 1  (max internal steps per loop)
 end
 
@@ -286,29 +287,34 @@ function RefinedTimeGrid(model::AuroraModel, mode::TimeDependentMode)
     # Total number of save intervals (-1 because we do not count the initial time t=0)
     n_save = length(t_save) - 1
 
-    # Determine number of loops based on memory constraints, or use the provided value
+    N_neutrals = length(model.species)
+
+    # Determine the number of loops from the memory budget, or use the provided value.
+    # The automatic path is already capped at n_save inside calculate_n_loop.
     n_loop_resolved = isnothing(n_loop) ?
-                      calculate_n_loop(t_internal, length(z), n_μ, n_E; max_memory_gb) :
-                      Int(n_loop)
-    # Check if it actually fits in RAM
-    check_n_loop(n_loop_resolved, length(z), n_μ, length(t_internal), n_E)
+        calculate_n_loop(length(z), n_μ, n_E, length(t_internal), N_neutrals, CFL_factor,
+                         n_save; max_memory_gb) :
+        Int(n_loop)
 
-    # Partition save intervals across loops.
-    # All loops except the last get n_save_per_loop intervals.
-    # The last gets the remainder (≤ n_save_per_loop).
-    n_save_per_loop = cld(n_save, n_loop_resolved)
-
-    # With ceiling division, the first (n_loop-1) loops can collectively consume more
-    # save intervals than exist, leaving the last loop with 0 or a negative count.
-    # This happens when (n_loop-1)*cld(n_save, n_loop) > n_save. Throw an error if
-    # this is the case.
-    n_last_loop = n_save - (n_loop_resolved - 1) * n_save_per_loop
-    if n_last_loop < 1
+    # A loop holds at least one save interval, so there cannot be more loops than save
+    # intervals. (Only reachable for a user-supplied n_loop; the auto path is capped.)
+    if n_loop_resolved > n_save
         throw(ArgumentError(
-            "n_loop=$n_loop_resolved is too large for n_save=$n_save: the last loop would " *
-            "have $n_last_loop save intervals (need ≥ 1). " *
-            "Reduce n_loop to ≤ $n_save, or increase duration/reduce dt."))
+            "n_loop=$n_loop_resolved is too large for n_save=$n_save: there cannot be more " *
+            "loops than save intervals. Reduce n_loop to ≤ $n_save, or increase duration / " *
+            "reduce dt."))
     end
+
+    # Check that the chosen split actually fits in RAM
+    check_n_loop(n_loop_resolved, length(z), n_μ, n_E, length(t_internal), N_neutrals,
+                 CFL_factor)
+
+    # Save intervals are partitioned across loops as evenly as possible (balanced
+    # partition, see `loop_save_count`): the first `rem(n_save, n_loop)` loops get
+    # `cld(n_save, n_loop)` intervals and the rest get `fld(n_save, n_loop)`. No loop is
+    # ever empty as long as n_loop ≤ n_save.
+    # `n_save_per_loop` is the *maximum* per-loop count, used to size the working arrays.
+    n_save_per_loop = cld(n_save, n_loop_resolved)
     # Maximum number of internal steps in a loop (used for cache allocation)
     n_t_per_loop = n_save_per_loop * CFL_factor + 1
 
@@ -321,15 +327,15 @@ end
 """
     loop_save_count(time::RefinedTimeGrid, i_loop) → Int
 
-Number of save intervals covered by loop `i_loop`. All loops except the last cover
-`time.n_save_per_loop` intervals; the last loop covers the remainder (≤ `n_save_per_loop`).
+Number of save intervals covered by loop `i_loop` under a balanced partition: the first
+`rem(n_save, n_loop)` loops carry `cld(n_save, n_loop)` intervals and the rest carry
+`fld(n_save, n_loop)`. Loop sizes differ by at most one and no loop is ever empty (for
+`n_loop ≤ n_save`). The counts sum to `time.n_save`.
 """
 function loop_save_count(time::RefinedTimeGrid, i_loop::Int)
-    if i_loop < time.n_loop
-        return time.n_save_per_loop
-    else
-        return time.n_save - (time.n_loop - 1) * time.n_save_per_loop
-    end
+    q, r = divrem(time.n_save, time.n_loop)
+    # The first `r` loops carry one extra save interval.
+    return q + (i_loop <= r ? 1 : 0)
 end
 
 """
@@ -346,8 +352,12 @@ loop_internal_count(time::RefinedTimeGrid, i_loop::Int) =
 
 Return index in `time.t_save` of the first (boundary) save point of loop `i_loop`.
 """
-loop_save_start(time::RefinedTimeGrid, i_loop::Int) =
-    (i_loop - 1) * time.n_save_per_loop + 1
+function loop_save_start(time::RefinedTimeGrid, i_loop::Int)
+    q, r = divrem(time.n_save, time.n_loop)
+    # Number of save intervals covered by loops 1 … i_loop-1 (balanced partition).
+    prev = (i_loop - 1) * q + min(i_loop - 1, r)
+    return prev + 1
+end
 
 """
     loop_internal_start(time::RefinedTimeGrid, i_loop) → Int
@@ -355,8 +365,12 @@ loop_save_start(time::RefinedTimeGrid, i_loop::Int) =
 Return index in `time.t` (the full internal grid) of the boundary point that starts
 loop `i_loop`.
 """
-loop_internal_start(time::RefinedTimeGrid, i_loop::Int) =
-    (i_loop - 1) * time.n_save_per_loop * time.CFL_factor + 1
+function loop_internal_start(time::RefinedTimeGrid, i_loop::Int)
+    q, r = divrem(time.n_save, time.n_loop)
+    # Save intervals before this loop, converted to internal-grid steps (balanced partition).
+    prev = (i_loop - 1) * q + min(i_loop - 1, r)
+    return prev * time.CFL_factor + 1
+end
 
 function Base.show(io::IO, time::RefinedTimeGrid)
     print(io, "RefinedTimeGrid(duration=$(time.duration), dt=$(time.dt), n_loop=$(time.n_loop))")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -423,7 +423,7 @@ function calculate_n_loop(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor, n_save;
         println()
     end
 
-    if budget_unmet
+    if budget_unmet && verbose
         @warn "Cannot keep the peak memory within max_memory_gb = $(max_memory_gb) GB " *
               "even with n_loop = $n_save (one save interval per loop). " *
               "Estimated peak: $(round(mem.fixed_gb + mem.scaling_gb / n_save, digits=2)) GB."
@@ -433,12 +433,13 @@ function calculate_n_loop(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor, n_save;
 end
 
 """
-    check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+    check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor; verbose=true)
 
 Verify that running with `n_loop` loops fits in the detected RAM. Errors if the estimated
-peak memory exceeds the available RAM, and warns if it exceeds half of it.
+peak memory exceeds the available RAM (always), and warns if it exceeds half of it (only
+when `verbose`).
 """
-function check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+function check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor; verbose::Bool=true)
     total_ram_gb = Sys.total_memory() / 1e9
     mem = estimate_simulation_memory(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
     peak_gb = mem.fixed_gb + mem.scaling_gb / n_loop
@@ -456,7 +457,7 @@ function check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
               "Estimated peak memory: $(round(peak_gb, digits=2)) GB\n" *
               "Detected RAM:          $(round(total_ram_gb, digits=2)) GB\n" *
               suggestion)
-    elseif peak_gb > 0.5 * total_ram_gb
+    elseif verbose && peak_gb > 0.5 * total_ram_gb
         @warn "n_loop = $n_loop may lead to high memory usage.\n" *
               "Estimated peak memory: $(round(peak_gb, digits=2)) GB\n" *
               "Detected RAM:          $(round(total_ram_gb, digits=2)) GB\n" *

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -355,96 +355,169 @@ end
 
 
 """
-    calculate_n_loop(t, n_z, n_μ, n_E; max_memory_gb=8, verbose=true)
+    calculate_n_loop(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor, n_save;
+                     max_memory_gb=8, verbose=true) → Int
 
-Calculate the optimal number of loops (`n_loop`) for the electron transport simulation
-based on memory constraints.
+Choose the number of loops (`n_loop`) for a time-dependent simulation so that the peak
+memory stays within `max_memory_gb`.
 
-This function determines how many time-slices the simulation should be divided into
-to stay within the specified memory limit.
+Using the split returned by [`estimate_simulation_memory`](@ref), the peak memory of an
+`n_loop`-loop run is ≈ `fixed_gb + scaling_gb / n_loop`. The smallest `n_loop` satisfying
+`fixed_gb + scaling_gb / n_loop ≤ max_memory_gb` is therefore
+
+    n_loop = ceil(scaling_gb / (max_memory_gb - fixed_gb))
+
+The result is capped at `n_save`, because a loop cannot hold fewer than one save interval.
+If even one save interval per loop (or the fixed allocations alone) exceeds the budget, the
+maximum split `n_loop = n_save` is returned together with a warning.
 
 # Arguments
-- `t`: Time array after CFL refinement (from `CFL_criteria`)
-- `n_z::Int`: Number of altitude grid points
-- `n_μ::Int`: Number of pitch-angle beams
-- `n_E::Int`: Number of energy grid points
+- `n_z`, `n_μ`, `n_E`: altitude, pitch-angle and energy grid sizes
+- `n_t`: number of internal time steps over the *whole* simulation (full CFL-refined grid)
+- `N_neutrals`: number of neutral species
+- `CFL_factor`: internal sub-steps per save interval
+- `n_save`: total number of save intervals
 
 # Keyword Arguments
-- `max_memory_gb`: Maximum memory to use (GB). Defaults to 8 GB.
-- `verbose::Bool=true`: If true, print some information about the calculation
+- `max_memory_gb`: memory budget (GB). Defaults to 8 GB.
+- `verbose::Bool=true`: if true, print a short summary of the calculation
 
 # Returns
-- `n_loop::Int`: Recommended number of loops
-
-# Example
-```julia
-t, CFL_factor = CFL_criteria(1.0, 0.001, h_atm, v_of_E(10000))
-n_loop = calculate_n_loop(t, length(h_atm), n_μ, n_E)
-```
+- `n_loop::Int`: recommended number of loops
 """
-function calculate_n_loop(t, n_z, n_μ, n_E; max_memory_gb=8, verbose=true)
-    # Number of time points after CFL refinement
-    n_t = length(t)
-    # Estimate memory for one loop
-    memory_total = estimate_simulation_memory(n_z, n_μ, n_t, n_E)
+function calculate_n_loop(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor, n_save;
+                          max_memory_gb=8, verbose=true)
+    mem = estimate_simulation_memory(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
 
-    # Calculate minimum n_loop needed
-    if memory_total <= max_memory_gb
-        n_loop = 1
+    budget_unmet = false
+    if mem.total_gb <= max_memory_gb
+        n_loop = 1                                  # everything fits in a single loop
+    elseif max_memory_gb <= mem.fixed_gb
+        # The split-independent allocations already exceed the budget; splitting cannot
+        # help, so fall back to the finest useful split.
+        n_loop = n_save
+        budget_unmet = true
     else
-        n_loop = ceil(Int, memory_total / max_memory_gb)
+        n_loop = ceil(Int, mem.scaling_gb / (max_memory_gb - mem.fixed_gb))
+        if n_loop > n_save                          # cannot split finer than 1 save/loop
+            n_loop = n_save
+            budget_unmet = true
+        end
     end
 
     if verbose
         println("Automatic n_loop calculation:")
         println("  Grid dimensions:")
-        println("    Altitude points (n_z):     $n_z")
-        println("    Pitch-angle beams (n_μ):   $n_μ")
-        println("    Time steps (n_t):          $n_t")
-        println("    Energy points (n_E):       $n_E")
+        println("    Altitude points (n_z):       $n_z")
+        println("    Pitch-angle beams (n_μ):     $n_μ")
+        println("    Time steps (n_t):            $n_t")
+        println("    Energy points (n_E):         $n_E")
         println("  ─────────────────────────────────────────")
-        println("  Total estimated memory use:  $(round(memory_total, digits=3)) GB")
-        println("  Total RAM detected:          $(round(Sys.total_memory() / 1e9, digits=2)) GB")
-        println("  Max memory limit:            $(round(max_memory_gb, digits=2)) GB")
+        println("  Fixed memory (not split):      $(round(mem.fixed_gb, digits=3)) GB")
+        println("  Time-scaling memory (1 loop):  $(round(mem.scaling_gb, digits=3)) GB")
+        println("  Single-loop total:             $(round(mem.total_gb, digits=3)) GB")
+        println("  Total RAM detected:            $(round(Sys.total_memory() / 1e9, digits=2)) GB")
+        println("  Max memory limit:              $(round(max_memory_gb, digits=2)) GB")
         println("  ─────────────────────────────────────────")
-        println("  Calculated n_loop:           $n_loop")
+        println("  Calculated n_loop:             $n_loop")
         println()
+    end
+
+    if budget_unmet
+        @warn "Cannot keep the peak memory within max_memory_gb = $(max_memory_gb) GB " *
+              "even with n_loop = $n_save (one save interval per loop). " *
+              "Estimated peak: $(round(mem.fixed_gb + mem.scaling_gb / n_save, digits=2)) GB."
     end
 
     return n_loop
 end
 
-function check_n_loop(n_loop, n_z, n_μ, n_t, n_E)
-    total_ram_gb = Sys.total_memory() / 1024^3
-    estimated_memory_gb = estimate_simulation_memory(n_z, n_μ, n_t, n_E)
-    memory_per_loop_gb = estimated_memory_gb / n_loop
-    if memory_per_loop_gb > total_ram_gb * 0.5
-        warn("The n_loop = $n_loop may lead to high memory usage.\n" *
-             "Estimated memory per loop: $(round(memory_per_loop_gb, digits=2)) GB\n" *
-             "Maximum RAM available (detected): $(round(total_ram_gb, digits=2)) GB\n" *
-             "Consider increasing `n_loop` or or decreasing `max_memory_gb` to avoid issues.")
-    elseif memory_per_loop_gb > total_ram_gb
-        error("The n_loop = $n_loop is too small for simulations to fit in available RAM.\n" *
-              "Estimated memory per loop: $(round(memory_per_loop_gb, digits=2)) GB\n" *
-              "Maximum RAM available (detected): $(round(total_ram_gb, digits=2)) GB\n" *
-              "Please increase `n_loop` to at least $(ceil(Int, estimated_memory_gb / total_ram_gb)) " *
-              "or decrease `max_memory_gb`.")
+"""
+    check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+
+Verify that running with `n_loop` loops fits in the detected RAM. Errors if the estimated
+peak memory exceeds the available RAM, and warns if it exceeds half of it.
+"""
+function check_n_loop(n_loop, n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+    total_ram_gb = Sys.total_memory() / 1e9
+    mem = estimate_simulation_memory(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+    peak_gb = mem.fixed_gb + mem.scaling_gb / n_loop
+
+    if peak_gb > total_ram_gb
+        # Smallest n_loop that would fit (if the fixed part alone already exceeds RAM,
+        # no split can help).
+        min_n_loop = mem.fixed_gb >= total_ram_gb ? nothing :
+                     ceil(Int, mem.scaling_gb / (total_ram_gb - mem.fixed_gb))
+        suggestion = isnothing(min_n_loop) ?
+            "The fixed allocations alone ($(round(mem.fixed_gb, digits=2)) GB) exceed the " *
+            "available RAM; reduce the grid size, duration or energy range." :
+            "Increase `n_loop` to at least $min_n_loop, or decrease `max_memory_gb`."
+        error("n_loop = $n_loop is too small to fit in the available RAM.\n" *
+              "Estimated peak memory: $(round(peak_gb, digits=2)) GB\n" *
+              "Detected RAM:          $(round(total_ram_gb, digits=2)) GB\n" *
+              suggestion)
+    elseif peak_gb > 0.5 * total_ram_gb
+        @warn "n_loop = $n_loop may lead to high memory usage.\n" *
+              "Estimated peak memory: $(round(peak_gb, digits=2)) GB\n" *
+              "Detected RAM:          $(round(total_ram_gb, digits=2)) GB\n" *
+              "Consider increasing `n_loop` or decreasing `max_memory_gb`."
     end
 end
 
-function estimate_simulation_memory(n_z::Int, n_μ::Int, n_t::Int, n_E::Int)
-    bytes_per_float64 = 8
+"""
+    estimate_simulation_memory(n_z, n_μ, n_E, n_t, N_neutrals, CFL_factor)
+        → (; fixed_gb, scaling_gb, total_gb)
 
-    # Main Ie array: (n_z * n_μ) x n_t x n_E
-    Ie_elements = n_z * n_μ * n_t * n_E
-    Ie_bytes = Ie_elements * bytes_per_float64
+Estimate the simulation's peak memory footprint (in decimal GB) by summing the actual
+working arrays allocated in [`build_simulation_cache`](@ref), rather than using a rough
+multiple of the `Ie` array.
 
-    # Total memory
-    # Q_array will have the same size as Ie, so we x2
-    # We also need some extra memory for temporary arrays during calculations, we use
-    # a factor x1.5 for that
-    total_memory_bytes = 2 * Ie_bytes * 1.5
-    memory_gb = total_memory_bytes / 1e9
+The footprint is split into two parts:
 
-    return memory_gb
+- `scaling_gb`: arrays laid out along the internal time grid — `cache.Ie`, `matrices.Q`,
+  the energy-degradation working arrays, and the subsampled `cache.Ie_save` buffer.
+  Evaluated here at the *full* internal length `n_t`; splitting the run into `n_loop`
+  loops shrinks this contribution to ≈ `scaling_gb / n_loop`.
+- `fixed_gb`: arrays whose size does **not** depend on the loop split — most importantly
+  `cache.Ie_top`, which always stores the entire input flux over the full time grid, plus
+  `cache.I0`, the transport/scattering matrices and the sparse solver factorisation.
+
+`total_gb = fixed_gb + scaling_gb` is the single-loop (`n_loop = 1`) footprint, so the peak
+memory of an `n_loop`-loop run is ≈ `fixed_gb + scaling_gb / n_loop`.
+"""
+function estimate_simulation_memory(n_z::Int, n_μ::Int, n_E::Int, n_t::Int,
+                                    N_neutrals::Int, CFL_factor::Int)
+    F = 8            # bytes per Float64
+    GB = 1e9         # decimal GB, to match the human-facing `max_memory_gb`
+    n_zμ = n_z * n_μ
+    # Number of save intervals (the internal grid has n_t = n_save * CFL_factor + 1 points)
+    n_save = (n_t - 1) ÷ CFL_factor
+
+    # ── Arrays sized along the internal time grid (shrink by ≈ 1/n_loop when split) ──
+    Ie      = n_zμ * n_t * n_E                  # cache.Ie
+    Q       = n_zμ * n_t * n_E                  # matrices.Q
+    Ie_save = n_zμ * (n_save + 1) * n_E         # cache.Ie_save (subsampled to save cadence)
+    # cache.degradation working arrays, summed over the N_neutrals species:
+    #   secondary_e_flux + primary_e_flux  → 2·N·(n_zμ·n_t)
+    #   Ie_scatter                         → n_zμ·n_t
+    #   ionization_source_sum              → n_z·n_t
+    degradation = (2 * N_neutrals + 1) * n_zμ * n_t + n_z * n_t
+    scaling_elems = Ie + Q + Ie_save + degradation
+
+    # ── Arrays independent of the loop split ──
+    Ie_top   = n_μ * n_t * n_E                  # cache.Ie_top — full input flux, never split
+    I0       = n_zμ * n_E                       # cache.I0
+    # Transport matrices: A (n_z) + B (n_z·n_μ²) + D (n_E·n_μ) + Ddiffusion (≈3·n_z stored)
+    matrices = n_z + n_z * n_μ^2 + n_E * n_μ + 3 * n_z
+    # Degradation energy spectra (2·N·n_E) + thermal-loss vector (n_z)
+    misc     = 2 * N_neutrals * n_E + n_z
+    # Sparse solver (Mlhs, Mrhs and the KLU factorisation). Both matrices share a block
+    # structure with ≈ n_μ²·n_z stored values; KLU fill-in inflates this, so allow a
+    # generous ×10 (still tiny next to Ie/Q because there is no n_E factor here).
+    solver   = 10 * n_μ^2 * n_z
+    fixed_elems = Ie_top + I0 + matrices + misc + solver
+
+    scaling_gb = scaling_elems * F / GB
+    fixed_gb   = fixed_elems   * F / GB
+    return (; fixed_gb, scaling_gb, total_gb = fixed_gb + scaling_gb)
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -470,8 +470,7 @@ end
         → (; fixed_gb, scaling_gb, total_gb)
 
 Estimate the simulation's peak memory footprint (in decimal GB) by summing the actual
-working arrays allocated in [`build_simulation_cache`](@ref), rather than using a rough
-multiple of the `Ie` array.
+working arrays allocated in [`build_simulation_cache`](@ref).
 
 The footprint is split into two parts:
 
@@ -489,7 +488,7 @@ memory of an `n_loop`-loop run is ≈ `fixed_gb + scaling_gb / n_loop`.
 function estimate_simulation_memory(n_z::Int, n_μ::Int, n_E::Int, n_t::Int,
                                     N_neutrals::Int, CFL_factor::Int)
     F = 8            # bytes per Float64
-    GB = 1e9         # decimal GB, to match the human-facing `max_memory_gb`
+    GB = 1e9         # decimal GB, to match the user-facing `max_memory_gb`
     n_zμ = n_z * n_μ
     # Number of save intervals (the internal grid has n_t = n_save * CFL_factor + 1 points)
     n_save = (n_t - 1) ÷ CFL_factor

--- a/test/simulation/test_time.jl
+++ b/test/simulation/test_time.jl
@@ -70,6 +70,38 @@ end
     @test AURORA.loop_save_count(t_d, 1) == 2
     @test AURORA.loop_save_count(t_d, 2) == 2
     @test AURORA.loop_save_count(t_d, 3) == 2
+
+    # Balanced partition: n_save=5, n_loop=4  →  [2, 1, 1, 1] (the old cld+remainder
+    # scheme produced [2, 2, 2, -1] here and wrongly rejected this valid config).
+    sim_b = AuroraSimulation(TimeTestModel.model, flux, mktempdir();
+                             mode=TimeDependentMode(duration=0.05, dt=0.01,
+                                                    CFL_number=128, n_loop=4))
+    t_b = sim_b.time
+    @test t_b.n_save == 5
+    @test [AURORA.loop_save_count(t_b, i) for i in 1:4] == [2, 1, 1, 1]
+    @test sum(AURORA.loop_save_count(t_b, i) for i in 1:4) == t_b.n_save
+
+    # No loop is ever empty for any valid n_loop ≤ n_save, and counts stay balanced
+    # (max − min ≤ 1) with a correct total.
+    for nl in 1:5
+        sim_n = AuroraSimulation(TimeTestModel.model, flux, mktempdir();
+                                 mode=TimeDependentMode(duration=0.05, dt=0.01,
+                                                        CFL_number=128, n_loop=nl))
+        counts = [AURORA.loop_save_count(sim_n.time, i) for i in 1:nl]
+        @test sum(counts) == 5
+        @test minimum(counts) >= 1
+        @test maximum(counts) - minimum(counts) <= 1
+    end
+end
+
+@testitem "RefinedTimeGrid: n_loop > n_save is rejected" setup=[TimeTestModel] begin
+    using AURORA
+    flux = InputFlux(FlatSpectrum(1.0; E_min=50.0); beams=1:2)
+
+    # n_save=5, requesting n_loop=6 is impossible (a loop must hold ≥ 1 save interval).
+    @test_throws ArgumentError AuroraSimulation(
+        TimeTestModel.model, flux, mktempdir();
+        mode=TimeDependentMode(duration=0.05, dt=0.01, CFL_number=128, n_loop=6))
 end
 
 @testitem "RefinedTimeGrid: loop_internal_start covers disjoint windows" setup=[TimeTestModel] begin
@@ -138,6 +170,26 @@ end
             t_all = Array(ds["time"])
 
             # Full time axis equals the expected uniform save grid
+            expected = collect(range(0.0, 0.05; length=6))
+            @test length(t_all) == 6
+            @test t_all ≈ expected  atol=1e-12
+        end
+    end
+end
+
+@testitem "Time-dependent 4 loops (balanced, uneven): t_run is exact" setup=[TimeTestModel] begin
+    using NCDatasets
+    mktempdir() do savedir
+        flux = InputFlux(FlatSpectrum(1e-2; E_min=50.0), SmoothOnset(0.0, 0.05); beams=1:2)
+
+        # duration=0.05s, dt=0.01s, n_save=5, n_loop=4  →  loop sizes [2, 1, 1, 1]
+        sim = AuroraSimulation(TimeTestModel.model, flux, savedir;
+                               mode=TimeDependentMode(duration=0.05, dt=0.01,
+                                                      CFL_number=128, n_loop=4))
+        run!(sim; verbose=false)
+
+        NCDataset(joinpath(savedir, "simulation_data.nc"), "r") do ds
+            t_all = Array(ds["time"])
             expected = collect(range(0.0, 0.05; length=6))
             @test length(t_all) == 6
             @test t_all ≈ expected  atol=1e-12


### PR DESCRIPTION
## Loop partitioning

- Replace the `cld`+remainder save-interval partition (which produced empty/negative last loops for valid configs such as `n_save=5, n_loop=4` → `[2, 2, 2, -1]`) with a **balanced partition**: the first `rem(n_save, n_loop)` loops get `cld(n_save, n_loop)` intervals and the rest get `fld(n_save, n_loop)`. No loop is ever empty for `n_loop ≤ n_save`.

- Auto-computed `n_loop` is now capped at `n_save`: the automatic memory path no longer throws a confusing "reduce `n_loop`" error for a value the user never set. An explicitly requested `n_loop > n_save` is still rejected.

## Memory estimation

Rework `estimate_simulation_memory` to sum the **actual** working arrays instead of `(Ie + Q) * 1.5`, split into:

- a **fixed** part — `Ie_top` (held at the full time length regardless of `n_loop`), plus `I0`, the transport matrices and the sparse solver;
- a **time-scaling** part — `Ie`, `Q`, the degradation buffers and `Ie_save`.

`calculate_n_loop` now solves `fixed + scaling / n_loop ≤ max_memory_gb` for `n_loop`, and `check_n_loop` compares the estimated peak (`fixed + scaling / n_loop`) against the detected RAM.

## Verbose

`build_time_config`/`RefinedTimeGrid` now take a `verbose` keyword (default `false`), forwarded from `initialize!`/`run!`. Constructing an `AuroraSimulation` stays quiet; the `n_loop` memory table and the soft memory warnings only print when `verbose=true`. The hard out-of-RAM error in `check_n_loop` still fires unconditionally.

## Tests

Add regression tests for the balanced partition (including the previously-broken `n_save=5, n_loop=4` → `[2, 1, 1, 1]` case) and the `n_loop > n_save` rejection.

> Note: Should be merged on top of #145