### PR TITLE
Fix altitude grid construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- Fix altitude-grid construction bugs (legacy grid shape unchanged) [#XXX](https://github.com/egavazzi/AURORA.jl/pull/XXX)
+  - A `bottom_altitude` above 100 km is now honoured (the grid snaps to the nearest grid point at or above it) instead of silently collapsing back to a grid starting at 100 km.
+  - The uniform segment below 100 km now lands exactly on the transition, removing the anomalous step that could straddle 100 km.
+  - The grid is no longer capped at ~500 points: it extends as far up as needed to reach `top_altitude`.
+  - `AltitudeGrid.bottom`/`top` now report the actual grid endpoints.
 - **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125) [#126](https://github.com/egavazzi/AURORA.jl/pull/126) [#138](https://github.com/egavazzi/AURORA.jl/pull/138)
   - Simulations are now set up by building an `AuroraModel`, constructing an `AuroraSimulation`, and calling `run!(sim)`. The functions `calculate_e_transport()` and `calculate_e_transport_steady_state()` are removed.
   - Neutral species can be inspected, modified, removed or even added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-- Fix altitude-grid construction bugs (legacy grid shape unchanged) [#XXX](https://github.com/egavazzi/AURORA.jl/pull/XXX)
-  - A `bottom_altitude` above 100 km is now honoured (the grid snaps to the nearest grid point at or above it) instead of silently collapsing back to a grid starting at 100 km.
-  - The uniform segment below 100 km now lands exactly on the transition, removing the anomalous step that could straddle 100 km.
-  - The grid is no longer capped at ~500 points: it extends as far up as needed to reach `top_altitude`.
-  - `AltitudeGrid.bottom`/`top` now report the actual grid endpoints.
 - **Breaking** :sparkles: New simulation interface :sparkles: [#114](https://github.com/egavazzi/AURORA.jl/pull/114) [#125](https://github.com/egavazzi/AURORA.jl/pull/125) [#126](https://github.com/egavazzi/AURORA.jl/pull/126) [#138](https://github.com/egavazzi/AURORA.jl/pull/138)
   - Simulations are now set up by building an `AuroraModel`, constructing an `AuroraSimulation`, and calling `run!(sim)`. The functions `calculate_e_transport()` and `calculate_e_transport_steady_state()` are removed.
   - Neutral species can be inspected, modified, removed or even added.
@@ -24,6 +19,7 @@
 - Switch from IRI2016 to IRI2020 model, solving the issue with recent dates that could not be computed [#117](https://github.com/egavazzi/AURORA.jl/pull/117)
 - Handle invalid iri values at top and bottom ends [#118](https://github.com/egavazzi/AURORA.jl/pull/118)
 - Cached cascading and scattering matrices created with different versions of AURORA are now automatically skipped [#135](https://github.com/egavazzi/AURORA.jl/pull/135/)
+- Fix some altitude grid construction bugs [#157](https://github.com/egavazzi/AURORA.jl/pull/157)
 
 ## v0.7.0 - 2026-03-25
 - **Breaking** Rename `animate_IeztE_3Dzoft` to `animate_Ie_in_time` [#89](https://github.com/egavazzi/AURORA.jl/pull/89)

--- a/src/grids/altitude_grid.jl
+++ b/src/grids/altitude_grid.jl
@@ -27,17 +27,18 @@ function AltitudeGrid(bottom, top; dz_max=25)
     h = make_altitude_grid(bottom, top; dz_max=dz_max)
     Δh = diff(h)
     FT = eltype(h)
-    return AltitudeGrid{FT, typeof(h)}(h, Δh, length(h), FT(bottom), FT(top))
+    return AltitudeGrid{FT, typeof(h)}(h, Δh, length(h), FT(h[1] / 1e3), FT(h[end] / 1e3))
 end
 
 """
     make_altitude_grid(bottom_altitude, top_altitude; dz_max=25)
 
-Create an altitude grid based on the altitude limits given as input. It uses
-constant steps of 150m for altitudes below 100km, and a non-linear grid above 100km.
+Create an altitude grid based on the altitude limits given as input. It uses constant
+steps below 100 km, and a non-linear grid (steps growing with altitude, capped at
+`dz_max`) above 100 km.
 
 # Calling
-`h_atm = make_altitude_grid(bottom_altitude, top_altitude; max_dz=25)`
+`h_atm = make_altitude_grid(bottom_altitude, top_altitude; dz_max=25)`
 
 # Arguments
 - `bottom_altitude`: altitude, in km, for the bottom of the simulation
@@ -47,22 +48,51 @@ constant steps of 150m for altitudes below 100km, and a non-linear grid above 10
 - `dz_max = 25`: maximum step size, in km. Relevant for high altitudes where the numbers
     can get large.
 
+# Notes
+- A `bottom_altitude` above 100 km is honoured (the grid snaps to the nearest grid point
+    at or above it) instead of silently collapsing back to 100 km.
+- The uniform segment below 100 km lands exactly on the transition, so there is no
+    anomalous step straddling 100 km.
+- The grid extends as far up as needed to reach `top_altitude`; there is no hard-coded
+    cap on the number of points.
+
 # Outputs
 - `h_atm`: altitude (m). Vector [nZ]
 """
 function make_altitude_grid(bottom_altitude, top_altitude; dz_max = 25)
-    Δz(n) = 150 .+
-            150 / 200 * (0:(n - 1)) .+
-            1.2 * exp.(Complex.(((0:(n - 1)) .- 150) / 22) .^ 0.9)
-    dz = real.(Δz(500))
-    dz = min.(dz, dz_max * 1e3)
-    # With the default dz_max of 25 km, the grid can go up to ~2700 km (which is way
-    # too high, don't do that).
-    h_atm = 100e3 .+ cumsum(dz) .- dz[1]
-    h_atm = vcat((bottom_altitude * 1e3):(h_atm[2] - h_atm[1]):h_atm[1], h_atm[2:end]) # add altitude steps under 100km
-    i_zmax = findlast(h_atm .<= top_altitude * 1e3)
-    h_atm = h_atm[1:i_zmax]
-    return h_atm
+    bottom_altitude < top_altitude || throw(ArgumentError(
+        "bottom_altitude must be below top_altitude, got $(bottom_altitude) ≥ $(top_altitude)."))
+    bot_m, top_m, z_transition = bottom_altitude * 1e3, top_altitude * 1e3, 100e3
+
+    # Legacy step-growth profile above the transition; step number `n` = 1, 2, …, capped at
+    # `dz_max`. The shape is unchanged from the previous version — only the assembly around
+    # it is fixed below.
+    step_at(n) = min(real(150 + 150 / 200 * n + 1.2 * exp(Complex((n - 150) / 22)^0.9)),
+                     dz_max * 1e3)
+
+    # Graded segment from the transition up to `top`, generating as many steps as needed
+    # (the old code hard-coded 500 steps, which capped the point count and the reachable
+    # altitude).
+    graded = [z_transition]
+    n = 1
+    while graded[end] < top_m
+        push!(graded, graded[end] + step_at(n))
+        n += 1
+    end
+    graded = graded[graded .<= top_m]   # clip at the top (legacy behaviour, no resizing)
+
+    if bot_m ≥ z_transition
+        # Bottom in the F-region: snap to the nearest grid point at or above it, instead of
+        # silently collapsing the grid back to 100 km.
+        return graded[graded .≥ bot_m]
+    end
+
+    # Bottom below the transition: uniform fill landing exactly on the transition (or on
+    # `top`, if that is itself below 100 km), removing the old spacing anomaly at 100 km.
+    knee = min(z_transition, top_m)
+    n_sub = max(1, round(Int, (knee - bot_m) / step_at(1)))
+    sub = collect(range(bot_m, knee; length = n_sub + 1))
+    return knee < top_m ? vcat(sub[1:end - 1], graded) : sub
 end
 
 function Base.show(io::IO, grid::AltitudeGrid)

--- a/src/grids/altitude_grid.jl
+++ b/src/grids/altitude_grid.jl
@@ -34,7 +34,7 @@ end
     make_altitude_grid(bottom_altitude, top_altitude; dz_max=25)
 
 Create an altitude grid based on the altitude limits given as input. It uses constant
-steps below 100 km, and a non-linear grid (steps growing with altitude, capped at
+steps of 150 m below 100 km, and a non-linear grid (steps growing with altitude, capped at
 `dz_max`) above 100 km.
 
 # Calling
@@ -48,51 +48,40 @@ steps below 100 km, and a non-linear grid (steps growing with altitude, capped a
 - `dz_max = 25`: maximum step size, in km. Relevant for high altitudes where the numbers
     can get large.
 
-# Notes
-- A `bottom_altitude` above 100 km is honoured (the grid snaps to the nearest grid point
-    at or above it) instead of silently collapsing back to 100 km.
-- The uniform segment below 100 km lands exactly on the transition, so there is no
-    anomalous step straddling 100 km.
-- The grid extends as far up as needed to reach `top_altitude`; there is no hard-coded
-    cap on the number of points.
-
 # Outputs
 - `h_atm`: altitude (m). Vector [nZ]
 """
 function make_altitude_grid(bottom_altitude, top_altitude; dz_max = 25)
     bottom_altitude < top_altitude || throw(ArgumentError(
         "bottom_altitude must be below top_altitude, got $(bottom_altitude) ≥ $(top_altitude)."))
-    bot_m, top_m, z_transition = bottom_altitude * 1e3, top_altitude * 1e3, 100e3
+    bottom_m = bottom_altitude * 1e3
+    top_m    = top_altitude * 1e3
+    z_transition = 100e3
 
-    # Legacy step-growth profile above the transition; step number `n` = 1, 2, …, capped at
-    # `dz_max`. The shape is unchanged from the previous version — only the assembly around
-    # it is fixed below.
-    step_at(n) = min(real(150 + 150 / 200 * n + 1.2 * exp(Complex((n - 150) / 22)^0.9)),
+    # Step-growth profile above the transition
+    Δz(n) = min(real(150 +
+                     150 / 200 * n +
+                     1.2 * exp(Complex((n - 150) / 22)^0.9)),
                      dz_max * 1e3)
 
     # Graded segment from the transition up to `top`, generating as many steps as needed
-    # (the old code hard-coded 500 steps, which capped the point count and the reachable
-    # altitude).
     graded = [z_transition]
     n = 1
     while graded[end] < top_m
-        push!(graded, graded[end] + step_at(n))
+        push!(graded, graded[end] + Δz(n))
         n += 1
     end
-    graded = graded[graded .<= top_m]   # clip at the top (legacy behaviour, no resizing)
+    graded = graded[graded .<= top_m]   # clip at the top
 
-    if bot_m ≥ z_transition
-        # Bottom in the F-region: snap to the nearest grid point at or above it, instead of
-        # silently collapsing the grid back to 100 km.
-        return graded[graded .≥ bot_m]
+    # Bottom above transition: snap to the nearest grid point
+    if bottom_m ≥ z_transition
+        return graded[graded .≥ bottom_m]
     end
 
-    # Bottom below the transition: uniform fill landing exactly on the transition (or on
-    # `top`, if that is itself below 100 km), removing the old spacing anomaly at 100 km.
-    knee = min(z_transition, top_m)
-    n_sub = max(1, round(Int, (knee - bot_m) / step_at(1)))
-    sub = collect(range(bot_m, knee; length = n_sub + 1))
-    return knee < top_m ? vcat(sub[1:end - 1], graded) : sub
+    # Bottom below the transition: uniform fill landing exactly on the transition
+    n_sub = max(1, round(Int, (z_transition - bottom_m) / Δz(1)))
+    sub = collect(range(bottom_m, z_transition; length = n_sub + 1))
+    return vcat(sub[1:end - 1], graded)
 end
 
 function Base.show(io::IO, grid::AltitudeGrid)

--- a/src/grids/altitude_grid.jl
+++ b/src/grids/altitude_grid.jl
@@ -64,24 +64,24 @@ function make_altitude_grid(bottom_altitude, top_altitude; dz_max = 25)
                      1.2 * exp(Complex((n - 150) / 22)^0.9)),
                      dz_max * 1e3)
 
-    # Graded segment from the transition up to `top`, generating as many steps as needed
-    graded = [z_transition]
+    # Build grid from the transition up to `top`, generating as many steps as needed
+    h_atm = [z_transition]
     n = 1
-    while graded[end] < top_m
-        push!(graded, graded[end] + Δz(n))
+    while h_atm[end] < top_m
+        push!(h_atm, h_atm[end] + Δz(n))
         n += 1
     end
-    graded = graded[graded .<= top_m]   # clip at the top
+    h_atm = h_atm[h_atm .<= top_m]   # clip at the top
 
     # Bottom above transition: snap to the nearest grid point
     if bottom_m ≥ z_transition
-        return graded[graded .≥ bottom_m]
+        return h_atm[h_atm .≥ bottom_m]
     end
 
     # Bottom below the transition: uniform fill landing exactly on the transition
-    n_sub = max(1, round(Int, (z_transition - bottom_m) / Δz(1)))
-    sub = collect(range(bottom_m, z_transition; length = n_sub + 1))
-    return vcat(sub[1:end - 1], graded)
+    n_sub_points = max(1, round(Int, (z_transition - bottom_m) / Δz(1)))
+    sub_grid = collect(range(bottom_m, z_transition; length = n_sub_points + 1))
+    return vcat(sub_grid[1:end - 1], h_atm)
 end
 
 function Base.show(io::IO, grid::AltitudeGrid)

--- a/test/grids/test_grids.jl
+++ b/test/grids/test_grids.jl
@@ -41,10 +41,10 @@ end
 @testitem "AltitudeGrid is not capped at 500 points" begin
     # the old version hard-coded 500 graded steps, capping both the point count and the
     # reachable altitude
-    h = AURORA.make_altitude_grid(100, 3000)
+    h = AURORA.make_altitude_grid(100, 5000)
     @test length(h) > 500
-    @test h[end] ≤ 3000e3
-    @test 3000e3 - h[end] < maximum(diff(h))     # reached within one step of the top
+    @test h[end] ≤ 5000e3
+    @test 5000e3 - h[end] < maximum(diff(h))     # reached within one step of the top
 end
 
 @testitem "AltitudeGrid invalid inputs" begin

--- a/test/grids/test_grids.jl
+++ b/test/grids/test_grids.jl
@@ -3,13 +3,48 @@
 
     @test grid isa AltitudeGrid
     @test grid isa AURORA.AbstractGrid
-    @test grid.bottom == 80
-    @test grid.top == 700
     @test length(grid.h) == grid.n
     @test length(grid.Δh) == grid.n - 1
     @test all(grid.Δh .> 0) # ensure grid is strictly increasing
     @test grid.h[1] ≈ 80e3
     @test grid.h[end] ≤ 700e3
+    # bottom/top now report the actual grid endpoints
+    @test grid.bottom ≈ grid.h[1] / 1e3
+    @test grid.top ≈ grid.h[end] / 1e3
+    @test grid.bottom == 80
+    @test grid.top ≤ 700
+end
+
+@testitem "AltitudeGrid clean transition at 100 km" begin
+    # the uniform sub-100 km segment lands exactly on the bottom and on 100 km, with no
+    # anomalous step straddling the transition
+    h = AURORA.make_altitude_grid(80, 700)
+    @test h[1] == 80e3
+    @test 100e3 in h
+    i = findfirst(==(100e3), h)
+    Δ = diff(h)
+    @test all(isapprox.(Δ[1:(i - 1)], Δ[1]; rtol = 1e-6))      # uniform below the transition
+    @test isapprox(Δ[i], Δ[i - 1]; rtol = 0.05)               # no jump across 100 km
+end
+
+@testitem "AltitudeGrid bottom above 100 km" begin
+    # used to silently collapse to a grid starting at 100 km; now snaps to the nearest grid
+    # point at or above the requested bottom
+    grid = AltitudeGrid(250, 500)
+    @test grid.h[1] ≥ 250e3
+    @test grid.h[1] < 260e3                 # snapped close to the request
+    @test grid.bottom ≈ grid.h[1] / 1e3
+    @test all(grid.Δh .> 0)
+    @test grid.n < AltitudeGrid(100, 500).n / 2
+end
+
+@testitem "AltitudeGrid is not capped at 500 points" begin
+    # the old version hard-coded 500 graded steps, capping both the point count and the
+    # reachable altitude
+    h = AURORA.make_altitude_grid(100, 3000)
+    @test length(h) > 500
+    @test h[end] ≤ 3000e3
+    @test 3000e3 - h[end] < maximum(diff(h))     # reached within one step of the top
 end
 
 @testitem "AltitudeGrid invalid inputs" begin


### PR DESCRIPTION
- **Bottom above 100 km is honoured.** A requested `bottom_altitude` above 100 km used to
   make the sub-100 km fill range go empty, silently collapsing the grid back to one
   starting at 100 km. The grid now snaps to the nearest grid point at or above the
   requested bottom. (e.g. `AltitudeGrid(250, 500)` now starts at ~252 km, not 100 km.)
- **Clean transition at 100 km.** The uniform segment below 100 km now lands exactly on
   the transition, removing the anomalous step that could straddle 100 km when
   `(100 − bottom)` was not a whole number of steps.
- **No 500-point cap.** The graded segment was built from a hard-coded `Δz(500)`, which
   capped both the number of points and the reachable altitude. It now extends
   as many steps as needed to reach `top_altitude`.

Also: `AltitudeGrid.bottom`/`top` now report the **actual** grid endpoints (these fields
are only used for display).

### TODO
- [x] add an entry in CHANGELOG.md
