### PR TITLE
Warn when energy bins are wider than ionization thresholds

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -133,7 +133,49 @@ function initialize!(model::AuroraModel;
         sp.phase_fcn         = sp.phase_fcn_generator(θ, eg.E_centers)
         load_or_compute_cascading!(sp.cascading_data, eg; verbose, policy)
     end
+    warn_if_bins_wider_than_ionization_threshold(eg, model.species)
     model.initialized = true
+    return nothing
+end
+
+"""
+    warn_if_bins_wider_than_ionization_threshold(energy_grid, species)
+
+Warn if any energy bin is wider than the smallest ionization threshold of any species.
+
+The ionization bookkeeping is split between two code paths that are only consistent as
+long as every ionizing collision moves the primary electron out of its energy bin:
+`update_B!` retains the in-bin fraction `max(0, 1 - E_loss/ΔE)` of the scattered flux
+(zero whenever `ΔE < E_loss`), while the cascading matrices used in
+`compute_ionization_spectra!` redistribute one full primary (and its secondaries) to
+strictly lower bins. If a bin is wider than an ionization threshold, both paths are
+active at once for that channel and each ionizing collision produces up to ~2 primary
+electrons (and over-counted secondaries), breaking particle and energy conservation.
+
+The default grid from `make_energy_grid` saturates at ΔE ≈ 11.65 eV, below the default
+ionization thresholds of N2, O2 and O, so this only triggers for custom coarse grids or
+custom species with low ionization thresholds.
+"""
+function warn_if_bins_wider_than_ionization_threshold(energy_grid, species)
+    ΔE_max = maximum(energy_grid.ΔE)
+    offenders = String[]
+    for sp in species
+        E_levels = sp.excitation_levels
+        ionizing = axes(E_levels, 1)[2:end]
+        thresholds = [E_levels[i, 1] for i in ionizing if E_levels[i, 2] > 0]
+        isempty(thresholds) && continue
+        threshold_min = minimum(thresholds)
+        if ΔE_max > threshold_min
+            push!(offenders, "$(sp.name) ($(round(threshold_min; digits = 2)) eV)")
+        end
+    end
+    if !isempty(offenders)
+        @warn "The widest energy bin (ΔE = $(round(ΔE_max; digits = 2)) eV) is wider " *
+              "than the lowest ionization threshold of " * join(offenders, ", ") * ". " *
+              "Ionizing collisions in bins wider than the threshold over-count primary " *
+              "and secondary electrons (see " *
+              "`warn_if_bins_wider_than_ionization_threshold`). Use a finer energy grid."
+    end
     return nothing
 end
 

--- a/test/grids/test_grids.jl
+++ b/test/grids/test_grids.jl
@@ -88,3 +88,31 @@ end
     @test_throws ArgumentError PitchAngleGrid(180:-10:10)
     @test_throws ArgumentError PitchAngleGrid(0:10:180)
 end
+
+@testitem "Warn when energy bins are wider than ionization thresholds" begin
+    Warn = Base.CoreLogging.Warn
+
+    # N2-like species: row 1 is elastic, one excitation channel (no secondaries),
+    # ionization channels have a secondary count > 0 in column 2
+    E_levels_N2 = [0.0 0.0; 6.17 0.0; 15.581 1.0; 42.0 2.0]
+    species = [(; name = :N2, excitation_levels = E_levels_N2)]
+
+    # The default grid saturates below all default ionization thresholds → no warning
+    fine_grid = EnergyGrid(7000)
+    @test maximum(fine_grid.ΔE) < 15.581
+    @test_logs min_level = Warn AURORA.warn_if_bins_wider_than_ionization_threshold(
+        fine_grid, species)
+
+    # A coarse grid with bins wider than the threshold → one warning listing all
+    # offending species with their thresholds
+    coarse_grid = (; ΔE = [10.0, 50.0, 243.0])
+    species_two = [species[1], (; name = :O2, excitation_levels = [0.0 0.0; 12.072 1.0])]
+    @test_logs (:warn, r"ionization threshold of N2 \(15.58 eV\), O2 \(12.07 eV\)") begin
+        AURORA.warn_if_bins_wider_than_ionization_threshold(coarse_grid, species_two)
+    end
+
+    # A wide excitation channel alone (no ionization) must not warn
+    species_no_ion = [(; name = :X, excitation_levels = [0.0 0.0; 6.17 0.0])]
+    @test_logs min_level = Warn AURORA.warn_if_bins_wider_than_ionization_threshold(
+        coarse_grid, species_no_ion)
+end


### PR DESCRIPTION
AURORA expects every energy bin to be narrower than the smallest ionization threshold. This holds for the default grid (`make_energy_grid` saturates at ΔE ≈ 11.65 eV, below all default thresholds — O2 is the closest at 12.07 eV), but nothing enforced it. With this PR we add a warning at model initialization when a custom grid or custom species breaks that assumption, listing the offending species and thresholds.

## Why

`update_B!` applies the in-bin retention factor `max(0, 1 - E_loss/dE)` to all inelastic channels, including ionizing ones, while `compute_ionization_spectra!` independently renormalizes the cascading spectra so that one full primary (plus its secondaries) lands in strictly lower bins. These two paths are only consistent when every ionizing collision moves the primary out of its energy bin, i.e. when `dE < E_loss`. On a coarser grid both paths become active at once, and each ionizing collision then produces up to ~2 primaries and inflated secondaries, breaking particle and energy conservation.