### PR TITLE
Exclude zenodo doi from lint checking

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,6 +4,7 @@ exclude = [
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://egavazzi.github.io/AURORA.jl/stable$",
   "https://doi.org/10.1029/2019JA027608",
+  "https://doi.org/10.5281/zenodo.11238620",
 ]
 
 exclude_path = [


### PR DESCRIPTION
Grew tired of CI lint test failing every so often due to timeout of the zenodo doi. We now that this doi exists so we don't need to check it anyway.