### PR TITLE
Fix doc preview cleanup missing previews deployed after PR close

### DIFF
--- a/.github/workflows/DocCleanup.yml
+++ b/.github/workflows/DocCleanup.yml
@@ -3,6 +3,11 @@ name: Doc Preview Cleanup
 on:
   pull_request:
     types: [closed]
+  # The on-close trigger races with the PR's final docs build, which can deploy the
+  # preview minutes after the PR is closed. The weekly sweep catches those strays.
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
 
 # Ensure that only one "Doc Preview Cleanup" workflow force-pushes at a time
 concurrency:
@@ -14,20 +19,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout gh-pages branch
         uses: actions/checkout@v7
         with:
           ref: gh-pages
-      - name: Delete preview and history + push changes
+      - name: Delete previews of closed PRs and history + push changes
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -d "${preview_dir}" ]; then
+          removed=0
+          for dir in previews/PR*/; do
+              [ -d "$dir" ] || continue
+              pr="${dir#previews/PR}"
+              pr="${pr%/}"
+              state=$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json state --jq .state || echo UNKNOWN)
+              if [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ]; then
+                  git rm -rfq "$dir"
+                  removed=1
+              fi
+          done
+          if [ "$removed" = 1 ]; then
               git config user.name "Documenter.jl"
               git config user.email "documenter@juliadocs.github.io"
-              git rm -rf "${preview_dir}"
-              git commit -m "delete preview"
+              git commit -m "delete previews of closed PRs"
               git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
               git push --force origin gh-pages-new:gh-pages
           fi
-        env:
-          preview_dir: previews/PR${{ github.event.number }}


### PR DESCRIPTION
The on-close cleanup races with the PR's final docs build: the preview is often deployed to gh-pages minutes after the PR is merged, so the cleanup job finds nothing to delete and the preview sticks around forever. Previews for merged PRs #149, #151, #160, #169, #171 had accumulated this way (~7 MiB packed on gh-pages, which every default `git clone` downloads).

This changes the cleanup job to sweep all `previews/PR*` directories and delete those whose PR is closed, instead of only targeting the just-closed PR. A weekly cron and a manual `workflow_dispatch` trigger catch previews that land after their PR closes.