### PR TITLE
Replace adaptive double-ionization integration with a numerical-CDF method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- **Numerical Breaking (small)** The double-ionization cascading matrices are now computed with a numerical-CDF method with fixed Gauss–Legendre rules instead of adaptive 3-D cubature, making them ~4x faster to build at moderate grids and tractable at large ones (E_max ≳ 50 keV), with final analysis results changing by less than ~1e-5 (relative). The adaptive implementation is kept as the reference the test suite validates against [#174](https://github.com/egavazzi/AURORA.jl/pull/174)
 - **Numerical Breaking (small)** Faster single-ionization cascading matrix calculations and better report progress [#169](https://github.com/egavazzi/AURORA.jl/pull/169)
 - **Numerical Breaking (small)** Remove the ad-hoc spatial diffusion operator (`D·∂²Ie/∂z²`) from both the steady-state and time-dependent solvers [#168](https://github.com/egavazzi/AURORA.jl/pull/168)
   - The operator was meant to model the spread in arrival times of electrons within a finite (E, μ) bin, but in its current form it contributed nothing measurable, and it did not belong in the steady-state equations in the first place. The numerical diffusion of the advection scheme already produces a comparable spread at default resolution.

--- a/src/physics/cascading.jl
+++ b/src/physics/cascading.jl
@@ -340,6 +340,14 @@ The outer loop structure is identical for all species. The only species-specific
 - `spec.ionization_thresholds`, which define the ionization thresholds for the species and thus
     the number of transfer matrices to calculate.
 
+Single-ionization channels are integrated with adaptive cubature (`rtol = 1e-4`).
+Double-ionization channels use the numerical-CDF method with fixed Gauss-Legendre rules
+(see `fill_double_ionization_bin_cdf!`): on rows carrying real weight it agrees with a
+tight adaptive reference to a few 1e-4, and its cost stays bounded on large grids where
+adaptive integration of the 3-D integrands becomes intractable (E_max ≳ 50 keV). Rows just
+above the threshold (~1e-5 of the weight) are less accurate (up to ~1e-1); the test suite
+validates the method against the adaptive reference implementation.
+
 # Arguments
 - `spec::CascadingSpec` contains species name, ionization thresholds and secondary distribution law
 - `E_edges`: Energy grid edges to match (eV)
@@ -370,15 +378,12 @@ function calculate_cascading_matrices(spec::CascadingSpec, E_edges; verbose = tr
     use_tty = stdout isa Base.TTY
 
     # Pre-allocate hcubature work buffers, one per thread (heap located). Single-ionization
-    # integrands are 2-D. Double ionization integrands are 3-D.
+    # integrands are 2-D. The double-ionization path uses fixed Gauss-Legendre rules and
+    # needs no buffers.
     primary_bufs = [hcubature_buffer(DegradedCascadingIntegrand(0.0, 1.0, 0.0, spec.secondary_law),
                                      (0.0, 0.0), (1.0, 1.0)) for _ in 1:Threads.maxthreadid()]
     secondary_bufs = [hcubature_buffer(SecondaryCascadingIntegrand(0.0, 1.0, 0.0, spec.secondary_law),
                                        (0.0, 0.0), (1.0, 1.0)) for _ in 1:Threads.maxthreadid()]
-    double_primary_bufs = [hcubature_buffer(DoublePrimaryCascadingIntegrand(0.0, 1.0, 0.0, spec.secondary_law),
-                                            (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)) for _ in 1:Threads.maxthreadid()]
-    double_secondary_bufs = [hcubature_buffer(DoubleSecondaryCascadingIntegrand(0.0, 1.0, 0.0, spec.secondary_law),
-                                              (0.0, 0.0, 0.0), (1.0, 1.0, 1.0)) for _ in 1:Threads.maxthreadid()]
 
     # Loop over ionization thresholds
     for (i_pass, i_threshold) in enumerate(n_thresholds:-1:1)
@@ -403,10 +408,9 @@ function calculate_cascading_matrices(spec::CascadingSpec, E_edges; verbose = tr
                                             E_edges, E_left, threshold, i_primary, i_threshold,
                                             spec.secondary_law, primary_bufs[tid], secondary_bufs[tid])
             else
-                fill_double_ionization_bin!(primary_transfer_matrix, secondary_transfer_matrix,
-                                            E_edges, E_left, threshold, i_primary, i_threshold,
-                                            spec.secondary_law, double_primary_bufs[tid],
-                                            double_secondary_bufs[tid])
+                fill_double_ionization_bin_cdf!(primary_transfer_matrix, secondary_transfer_matrix,
+                                                E_edges, E_left, threshold, i_primary, i_threshold,
+                                                spec.secondary_law)
             end
             done = Threads.atomic_add!(bins_done, 1) + 1
             if verbose
@@ -506,15 +510,16 @@ function fill_single_ionization_bin!(primary_transfer_matrix, secondary_transfer
 end
 
 
-# Double-ionization (two secondaries) contribution for one primary bin. Builds the degraded-
-# primary distribution and the PER-secondary marginal via the 3-D joint integrands defined above. Both
-# matrices sum (over their output bins) to the same event count Z₂, so `compute_ionization_spectra!`
-# conserves energy unchanged. Bin ranges differ from single ionization: the degraded primary is
-# the highest-energy electron, so it reaches down only to W/3 (not W/2), while a single secondary
-# still maxes out at W/2.
-# We use a relative tolerance of 1e-3 for the 3-D integrals, which makes it much faster
-# (~230x faster with 2s vs 460s from testing on my laptop) while still keeping a < 0.1% error
-# on each cascading matrix entry.
+# REFERENCE implementation of the double-ionization (two secondaries) contribution for one
+# primary bin, via adaptive 3-D cubature of the joint integrands defined above. NOT used by
+# the production path (`fill_double_ionization_bin_cdf!` below): its cost per row grows
+# without bound on large grids (minutes per row at E_max ≳ 100 keV). It is kept as the
+# ground truth that the test suite validates the production path against, since its rtol
+# gives it a controlled error for any secondary law.
+# Both matrices sum (over their output bins) to the same event count Z₂, so
+# `compute_ionization_spectra!` conserves energy unchanged. Bin ranges differ from single
+# ionization: the degraded primary is the highest-energy electron, so it reaches down only
+# to W/3 (not W/2), while a single secondary still maxes out at W/2.
 function fill_double_ionization_bin!(primary_transfer_matrix, secondary_transfer_matrix,
                                      E_edges, E_left, threshold, i_primary, i_threshold,
                                      secondary_law, primary_buf, secondary_buf)
@@ -557,6 +562,254 @@ function fill_double_ionization_bin!(primary_transfer_matrix, secondary_transfer
                                  (E_secondary_upper, 1.0, 1.0);
                                  rtol = 1e-3, buffer = secondary_buf)
             secondary_transfer_matrix[i_primary, i_secondary, i_threshold] = result
+        end
+    end
+    return
+end
+
+
+# ======================================================================================== #
+#          NUMERICAL-CDF DOUBLE IONIZATION (generic secondary-law fallback)                 #
+# ======================================================================================== #
+
+# Four-, eight-, and sixteen-point Gauss-Legendre rules on [-1, 1].  The outer
+# primary/output-bin integrations use the four-point rule.  The cumulative-law table uses
+# the eight-point rule, and the constrained self-convolution uses sixteen points because it
+# may span the sharp low-energy part of a secondary law.
+const _GL4_X = (-0.8611363115940526, -0.3399810435848563,
+                 0.3399810435848563,  0.8611363115940526)
+const _GL4_W = ( 0.3478548451374539,  0.6521451548625461,
+                 0.6521451548625461,  0.3478548451374539)
+const _GL8_X = (-0.9602898564975363, -0.7966664774136267,
+                -0.5255324099163290, -0.1834346424956498,
+                 0.1834346424956498,  0.5255324099163290,
+                 0.7966664774136267,  0.9602898564975363)
+const _GL8_W = ( 0.1012285362903763,  0.2223810344533745,
+                 0.3137066458778873,  0.3626837833783620,
+                 0.3626837833783620,  0.3137066458778873,
+                 0.2223810344533745,  0.1012285362903763)
+const _GL16_X = (-0.9894009349916499, -0.9445750230732326,
+                 -0.8656312023878318, -0.7554044083550030,
+                 -0.6178762444026438, -0.4580167776572274,
+                 -0.2816035507792589, -0.0950125098376374,
+                  0.0950125098376374,  0.2816035507792589,
+                  0.4580167776572274,  0.6178762444026438,
+                  0.7554044083550030,  0.8656312023878318,
+                  0.9445750230732326,  0.9894009349916499)
+const _GL16_W = ( 0.0271524594117541,  0.0622535239386479,
+                  0.0951585116824928,  0.1246289712555339,
+                  0.1495959888165767,  0.1691565193950025,
+                  0.1826034150449236,  0.1894506104550685,
+                  0.1894506104550685,  0.1826034150449236,
+                  0.1691565193950025,  0.1495959888165767,
+                  0.1246289712555339,  0.0951585116824928,
+                  0.0622535239386479,  0.0271524594117541)
+
+@inline function _checked_secondary_law(law, E_secondary, E_primary)
+    value = law(E_secondary, E_primary)
+    isfinite(value) || throw(DomainError(value, "secondary law must be finite"))
+    value >= 0 || throw(DomainError(value, "secondary law must be nonnegative"))
+    return value
+end
+
+@inline function _gauss(f, a, b, X, W)
+    b > a || return 0.0
+    midpoint = (a + b) / 2
+    halfwidth = (b - a) / 2
+    result = 0.0
+    @inbounds for k in eachindex(X)
+        result += W[k] * f(midpoint + halfwidth * X[k])
+    end
+    return halfwidth * result
+end
+_gauss4(f, a, b) = _gauss(f, a, b, _GL4_X, _GL4_W)
+_gauss8(f, a, b) = _gauss(f, a, b, _GL8_X, _GL8_W)
+
+"""
+Numerical cumulative integral of a custom secondary law at one fixed primary energy.
+
+`cumulative[k]` is the integral from zero through `edges[k]`.  The energy-grid edges are
+used as knots, so the importance map never needs to resolve structure finer than an output
+energy bin.  The bin masses themselves are evaluated with eight-point Gauss-Legendre
+quadrature rather than assuming a particular analytical law.
+"""
+struct NumericalSecondaryCDF{F}
+    edges::Vector{Float64}
+    cumulative::Vector{Float64}
+    E_primary::Float64
+    law::F
+end
+
+"""
+Build a `NumericalSecondaryCDF` for one fixed primary energy, using the energy-grid edges (up
+to `E_max`) as CDF knots and eight-point Gauss-Legendre quadrature for each knot-interval mass.
+
+Named separately from the struct's implicit field constructor (which has the same arity) so
+that call sites unambiguously request the built-from-scratch cumulative table.
+"""
+function build_secondary_cdf(E_edges, E_max, E_primary, law)
+    edges = Float64[0.0]
+    for edge in E_edges
+        edge <= 0 && continue
+        edge >= E_max && break
+        push!(edges, edge)
+    end
+    E_max > 0 && push!(edges, Float64(E_max))
+
+    cumulative = zeros(length(edges))
+    for i in 1:(length(edges) - 1)
+        mass = _gauss8(edges[i], edges[i + 1]) do E_secondary
+            _checked_secondary_law(law, E_secondary, E_primary)
+        end
+        cumulative[i + 1] = cumulative[i] + mass
+    end
+    return NumericalSecondaryCDF(edges, cumulative, Float64(E_primary), law)
+end
+
+# Accurate cumulative-law value.  Completed knot intervals come from the prefix table; only
+# the final partial interval is integrated here.
+@inline function cumulative_law(cdf::NumericalSecondaryCDF, energy)
+    energy <= 0 && return 0.0
+    energy >= cdf.edges[end] && return cdf.cumulative[end]
+    i = searchsortedlast(cdf.edges, energy)
+    prefix = cdf.cumulative[i]
+    partial = _gauss8(cdf.edges[i], energy) do E_secondary
+        _checked_secondary_law(cdf.law, E_secondary, cdf.E_primary)
+    end
+    return prefix + partial
+end
+
+# Piecewise-linear cumulative coordinate used solely as an importance map.  Returning its
+# local slope makes the subsequent change of variables exact for this map: the physical law
+# is still evaluated explicitly and divided by dC/dE.
+@inline function cumulative_map(cdf::NumericalSecondaryCDF, energy)
+    energy <= 0 && return 0.0
+    energy >= cdf.edges[end] && return cdf.cumulative[end]
+    i = searchsortedlast(cdf.edges, energy)
+    fraction = (energy - cdf.edges[i]) / (cdf.edges[i + 1] - cdf.edges[i])
+    return cdf.cumulative[i] +
+           fraction * (cdf.cumulative[i + 1] - cdf.cumulative[i])
+end
+
+@inline function inverse_cumulative_map(cdf::NumericalSecondaryCDF, cumulative_value)
+    cumulative_value <= 0 && return (0.0, Inf)
+    cumulative_value >= cdf.cumulative[end] && return (cdf.edges[end], Inf)
+
+    i = searchsortedlast(cdf.cumulative, cumulative_value)
+    i = min(i, length(cdf.cumulative) - 1)
+    # Flat cumulative intervals represent zero-mass bins.  Interior Gauss nodes should not
+    # land there, but skip them defensively for custom laws with compact/disjoint support.
+    while i < length(cdf.cumulative) && cdf.cumulative[i + 1] <= cumulative_value
+        i += 1
+    end
+    i >= length(cdf.cumulative) && return (cdf.edges[end], Inf)
+
+    mass = cdf.cumulative[i + 1] - cdf.cumulative[i]
+    mass > 0 || return (cdf.edges[i], Inf)
+    width = cdf.edges[i + 1] - cdf.edges[i]
+    fraction = (cumulative_value - cdf.cumulative[i]) / mass
+    return cdf.edges[i] + fraction * width, mass / width
+end
+
+@inline function double_secondary_density(E_secondary, E_primary, threshold,
+                                           law, cdf::NumericalSecondaryCDF)
+    W = E_primary - threshold
+    (0 <= E_secondary <= W / 2) || return 0.0
+    partner_upper = min(W - 2 * E_secondary, (W - E_secondary) / 2)
+    partner_upper > 0 || return 0.0
+    return _checked_secondary_law(law, E_secondary, E_primary) *
+           cumulative_law(cdf, partner_upper)
+end
+
+@inline function double_primary_density_cdf(E_degraded, E_primary, threshold,
+                                             law, cdf::NumericalSecondaryCDF)
+    W = E_primary - threshold
+    (W / 3 <= E_degraded <= W) || return 0.0
+    secondary_sum = W - E_degraded
+    secondary_sum > 0 || return 0.0
+
+    E_lower = max(0.0, secondary_sum - E_degraded)
+    E_mid = secondary_sum / 2
+    C_lower = cumulative_map(cdf, E_lower)
+    C_mid = cumulative_map(cdf, E_mid)
+    C_width = C_mid - C_lower
+    C_width > 0 || return 0.0
+
+    # The convolution interval is symmetric about secondary_sum/2.  Integrate its lower
+    # half in the numerical cumulative coordinate and double it.  Mapping y from [-1,1]
+    # to [C_lower,C_mid] and applying the symmetry factor leaves the prefactor C_width.
+    result = 0.0
+    @inbounds for k in eachindex(_GL16_X)
+        C = (C_lower + C_mid) / 2 + (C_width / 2) * _GL16_X[k]
+        E_secondary, map_density = inverse_cumulative_map(cdf, C)
+        isfinite(map_density) || continue
+        physical_density = _checked_secondary_law(law, E_secondary, E_primary)
+        partner_density = _checked_secondary_law(law,
+                                                  secondary_sum - E_secondary,
+                                                  E_primary)
+        result += _GL16_W[k] * physical_density * partner_density / map_density
+    end
+    return C_width * result
+end
+
+"""
+Double-ionization row builder based on numerical marginalization.
+
+The primary-bin integral is a four-point Gauss-Legendre sum.  At each primary-energy node,
+a numerical CDF of the arbitrary secondary law removes the partner dimension from the
+secondary marginal and supplies an importance coordinate for the degraded-primary
+self-convolution.  Output-bin integrations are also four-point Gauss-Legendre sums.
+"""
+function fill_double_ionization_bin_cdf!(primary_transfer_matrix,
+                                         secondary_transfer_matrix,
+                                         E_edges, E_left, threshold,
+                                         i_primary, i_threshold, law)
+    E_primary_min = E_edges[i_primary]
+    E_primary_max = E_edges[i_primary + 1]
+    E_primary_mid = (E_primary_min + E_primary_max) / 2
+    E_primary_halfwidth = (E_primary_max - E_primary_min) / 2
+
+    # Accuracy limit of this fixed-order primary-bin rule: the output-bin clamps
+    # (max(edge, W/3), min(edge, W) for the degraded primary) introduce kinks in the
+    # integrand as E_primary sweeps the bin, which the four-point Gauss rule does not resolve.
+    # The least accurate rows are therefore the near-threshold ones, where W varies strongly
+    # across the bin. Measured worst per-row degraded-primary sum error is ~1.3e-3 vs the
+    # rtol=1e-3 hcubature reference on the standard 3 keV grid — physically negligible, since
+    # those rows carry little weight.
+    @inbounds for k_primary in eachindex(_GL4_X)
+        E_primary = E_primary_mid + E_primary_halfwidth * _GL4_X[k_primary]
+        primary_weight = E_primary_halfwidth * _GL4_W[k_primary]
+        W = E_primary - threshold
+        W > 0 || continue
+        cdf = build_secondary_cdf(E_edges, W / 2, E_primary, law)
+
+        # Degraded primary marginal: d in [W/3, W].
+        i_min_degraded = max(1, searchsortedlast(E_left, W / 3))
+        i_max_degraded = min(i_primary, searchsortedlast(E_left, W))
+        for i_degraded in i_min_degraded:i_max_degraded
+            lower = max(E_edges[i_degraded], W / 3)
+            upper = min(E_edges[i_degraded + 1], W)
+            upper > lower || continue
+            value = _gauss4(lower, upper) do E_degraded
+                double_primary_density_cdf(E_degraded, E_primary, threshold, law, cdf)
+            end
+            primary_transfer_matrix[i_primary, i_degraded, i_threshold] +=
+                primary_weight * value
+        end
+
+        # Per-secondary marginal: s in [0, W/2].  Energies below the grid floor remain
+        # unbinned exactly as in the HCubature implementation, but they are retained in the
+        # partner CDF and therefore still influence the on-grid marginal.
+        i_max_secondary = min(i_primary - 1, searchsortedlast(E_left, W / 2))
+        for i_secondary in 1:i_max_secondary
+            lower = E_edges[i_secondary]
+            upper = min(E_edges[i_secondary + 1], W / 2)
+            upper > lower || continue
+            value = _gauss4(lower, upper) do E_secondary
+                double_secondary_density(E_secondary, E_primary, threshold, law, cdf)
+            end
+            secondary_transfer_matrix[i_primary, i_secondary, i_threshold] +=
+                primary_weight * value
         end
     end
     return

--- a/test/physics/test_cascading_conservation.jl
+++ b/test/physics/test_cascading_conservation.jl
@@ -518,3 +518,70 @@ end
     # confirming the two secondaries are actually deposited rather than dropped.
     @test maximum(ratios) >= 0.95
 end
+
+
+# The production double-ionization path (numerical-CDF + fixed Gauss-Legendre rules,
+# `fill_double_ionization_bin_cdf!`) has no built-in error estimate, so validate it here
+# against the adaptive-cubature reference (`fill_double_ionization_bin!`, rtol = 1e-3),
+# which has a controlled error for any secondary law. Tolerances cover both methods'
+# quadrature errors: on rows carrying real weight both agree to a few 1e-3; rows just above
+# the threshold carry ~1e-5 of the weight and are allowed a looser bound (the fixed
+# primary-bin rule does not resolve the kinematic-clamp kinks there).
+@testitem "Cascading double-ionization CDF matches adaptive reference" begin
+    using AURORA
+    using HCubature: hcubature_buffer
+
+    law = AURORA.@law (E_s, E_p) -> 1.0 / (11.4^2 + E_s^2)
+    threshold = 42.0
+    spec = AURORA.CascadingSpec("TEST", [threshold], law; n_secondaries = [2])
+    E_edges, _, _ = AURORA.make_energy_grid(1500.0)
+    E_left = E_edges[1:end-1]
+    n_E = length(E_left)
+    i_first = searchsortedfirst(E_left, threshold)
+
+    # Production path
+    Qp, Qs, _, _ = AURORA.calculate_cascading_matrices(spec, E_edges; verbose = false)
+
+    # Adaptive reference, on every active row
+    P = zeros(n_E, n_E, 1)
+    S = zeros(n_E, n_E, 1)
+    pbuf = hcubature_buffer(AURORA.DoublePrimaryCascadingIntegrand(0.0, 1.0, 0.0, law),
+                            (0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+    sbuf = hcubature_buffer(AURORA.DoubleSecondaryCascadingIntegrand(0.0, 1.0, 0.0, law),
+                            (0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+    for i_p in i_first:n_E
+        AURORA.fill_double_ionization_bin!(P, S, E_edges, E_left, threshold, i_p, 1,
+                                           law, pbuf, sbuf)
+    end
+
+    for (ref, cdf) in ((P, Qp), (S, Qs))
+        row_ref = vec(sum(ref[:, :, 1]; dims = 2))
+        row_cdf = vec(sum(cdf[:, :, 1]; dims = 2))
+        w_max = maximum(row_ref)
+        for i in i_first:n_E
+            row_ref[i] > 0 || continue
+            rel = abs(row_cdf[i] - row_ref[i]) / max(row_ref[i], row_cdf[i])
+            if row_ref[i] > 0.01 * w_max
+                @test rel < 2e-2       # rows that matter: both methods within a few 1e-3
+            else
+                @test rel < 2e-1       # near-threshold rows: negligible weight, loose bound
+            end
+        end
+    end
+
+    # Internal consistency: both marginals count the same double-ionization events (Z₂), so
+    # their row sums must agree wherever all three outgoing electrons land on-grid. On the
+    # standard grid the secondary marginal loses the below-floor part of the law (~12 % for
+    # the ~1.9 eV floor) by design, so run this check on a zero-floor grid, where the two
+    # sums agree to a few 1e-4.
+    zero_floor_edges = vcat(0.0, 0.63, 1.27, E_edges)
+    Qp0, Qs0, _, _ = AURORA.calculate_cascading_matrices(spec, zero_floor_edges; verbose = false)
+    E_left0 = zero_floor_edges[1:end-1]
+    row_p = vec(sum(Qp0[:, :, 1]; dims = 2))
+    row_s = vec(sum(Qs0[:, :, 1]; dims = 2))
+    i_hi = searchsortedfirst(E_left0, 10 * threshold)
+    for i in i_hi:length(E_left0)
+        row_p[i] > 0 || continue
+        @test isapprox(row_p[i], row_s[i]; rtol = 5e-3)
+    end
+end


### PR DESCRIPTION
## Why

The double-ionization transfer matrices are built from 3-D integrals whose integrand contains the sharp low-energy peak of the secondary law (~11 eV wide). Adaptive cubature (`hcubature`) fights that peak by subdividing, and its cost explodes with grid size — measured on a single top-bin row (N₂, 42 eV channel):

| E_max | 30 keV | 50 keV | 100 keV | 300 keV |
|---|---|---|---|---|
| hcubature | 0.6 s | 32 s | 9 min | unfinished after 38 min |
| numerical-CDF (this PR) | 0.3 s | — | 0.5 s | 1.3 s |

The double pass already dominates the cascading build at moderate grids (~92 % of N₂ matrix time at 30 keV) and makes E_max ≳ 50 keV intractable.

## What

Double-ionization channels now use a numerical-CDF method with fixed Gauss–Legendre rules instead of adaptive 3-D cubature. Per primary-energy node, the cumulative of the secondary law is tabulated once on the grid edges and used twice: as an exact lookup for the partner-electron integral (removing one dimension), and as an importance map that concentrates the quadrature nodes of the remaining self-convolution inside the law's peak. Fixed 4/8/16-point rules replace adaptivity, so the cost per row is bounded and reuses one table across all output bins. The method is fully generic in the secondary law.

The adaptive implementation is kept as the reference the test suite validates against; a new testitem compares the production path against it row by row and checks that both marginals count the same number of ionization events (on a zero-floor grid, where that invariant is exact). Single-ionization channels are untouched.

## Why we can (accuracy)

Scored against a *tightened* adaptive reference (`rtol = 1e-5`, 3 keV grid, row sums; "heavy rows" carry >1 % of the maximum row weight):

| method | heavy rows (primary / secondary) | all rows |
|---|---|---|
| hcubature `rtol = 1e-3` (current production) | 3.4e-4 / 6.7e-3 | 3.4e-4 / 6.7e-3 |
| numerical-CDF (this PR) | 2.7e-4 / 9.3e-5 | 1.3e-3 / 8.2e-2 |

On the rows that carry weight, the new method is *more accurate* than the path it replaces — the exact-CDF lookup beats adaptive integration at `rtol = 1e-3` on the secondary marginal by ~70x. The 8.2e-2 worst case lives only on rows just above the threshold carrying ~1e-5 of the weight (the fixed primary-bin rule does not resolve the kinematic-clamp kinks there); raising the rule order does not fix a kink, and the physically correct fix (splitting at the known kink positions) is not worth the complexity at that weight.

End-to-end, the steady-state and time-dependent regression results change by at most ~9.5e-6 (relative) — an order of magnitude inside the 1e-4 regression tolerance, so the reference results stay as they are. The full test suite passes (34281 tests).

## Benchmarks

Full N₂ double-ionization pass, 8 threads: 30 keV grid 243 s → 59 s (~4x); 100 keV grid, previously intractable (a single row cost ~9 min single-threaded, extrapolating to days for the full pass) → 13.5 min. Cascading caches are keyed to the AURORA version, so existing caches are invalidated at the next release as usual.

The method was developed and validated on the energy-scan branch, where it has been running the 25–300 keV production scans.
